### PR TITLE
Updating line-ending settings to play nicer across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,11 @@
-* text=false
+* text=auto
+*.c text
+*.cpp text
+*.h text
+*.py text
+*.sln text eol=crlf
+*.vcxproj text eol=crlf
+*.vgdbsettings text eol=crlf
+*.filters text eol=crlf
+*.props text eol=crlf
+*.xml text eol=crlf


### PR DESCRIPTION
I've noticed a lot of line-ending issues reviewing diffs and working in the repo. Here's a proposal that keeps the forces the windows EOL on VisualStudio files and opts for automatic line endings on everything else. If there is a specific reason the line endings handling was not the default lmk.

Here's a helpful link I found, it also covers how to clean up your line endings automatically in your repo:

https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings

<img width="1452" alt="Screen Shot 2020-03-31 at 12 13 18 AM" src="https://user-images.githubusercontent.com/987907/77998708-5ad25600-72e6-11ea-8ef5-c4259109bd48.png">
