### PR TITLE
Made docs deployment conditional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,12 @@ jobs:
               - BUILD_DOCS=1
           deploy:
               provider: pages
-              skip_cleanup: true
               local_dir: doc/html
               keep_history: true
               github_token: $GH_REPO_TOKEN
               on:
                 branch: master
+                condition: $DEPLOY_DOCS == 1
 before_install:
     - |
         if [ "$BUILD" != "" ]; then


### PR DESCRIPTION
This helps developers to use Travis CI when working on their forks. Without this, builds will fail on forks because deployment of the docs is not possible.

For  `electro-smith/DaisySP` enable deployment by setting up `DEPLOY_DOCS=1` in Travis CI.