### PR TITLE
Adenv Silence fix

### DIFF
--- a/modules/adenv.cpp
+++ b/modules/adenv.cpp
@@ -141,7 +141,10 @@ float AdEnv::Process()
             current_segment_ = ADENV_SEG_IDLE;
         }
     }
-
+    if (current_segment_ == ADENV_SEG_IDLE) 
+    {
+        val = out = 0.0f;
+    }
     output_ = val;
 
     return out * (max_ - min_) + min_;

--- a/modules/adenv.cpp
+++ b/modules/adenv.cpp
@@ -141,7 +141,7 @@ float AdEnv::Process()
             current_segment_ = ADENV_SEG_IDLE;
         }
     }
-    if (current_segment_ == ADENV_SEG_IDLE) 
+    if(current_segment_ == ADENV_SEG_IDLE)
     {
         val = out = 0.0f;
     }


### PR DESCRIPTION
explicitly sets output to 0.0 when idling to avoid non-silent low amplitude output during idle