### PR TITLE
AdEnv bugfix

### DIFF
--- a/modules/adenv.cpp
+++ b/modules/adenv.cpp
@@ -96,10 +96,14 @@ float AdEnv::Process()
             break;
     }
 
-    // Handle recalculating things and whatnot
-    curve_x_ = 0;
-    phase_   = 0;
-    // This can happen only on transitions between curves
+    if(prev_segment_ != current_segment_)
+    {
+        //Reset at segment beginning
+        curve_x_ = 0;
+        phase_   = 0;
+    }
+
+    //recalculate increment value
     if(curve_scalar_ == 0.0f)
     {
         c_inc_ = (end - beg) / time_samps;
@@ -108,6 +112,7 @@ float AdEnv::Process()
     {
         c_inc_ = (end - beg) / (1.0f - EXPF(curve_scalar_));
     }
+
 
     // update output
     val = output_;

--- a/modules/adenv.cpp
+++ b/modules/adenv.cpp
@@ -96,20 +96,17 @@ float AdEnv::Process()
             break;
     }
 
-    if(prev_segment_ != current_segment_)
+    // Handle recalculating things and whatnot
+    curve_x_ = 0;
+    phase_   = 0;
+    // This can happen only on transitions between curves
+    if(curve_scalar_ == 0.0f)
     {
-        // Handle recalculating things and whatnot
-        curve_x_ = 0;
-        phase_   = 0;
-        // This can happen only on transitions between curves
-        if(curve_scalar_ == 0.0f)
-        {
-            c_inc_ = (end - beg) / time_samps;
-        }
-        else
-        {
-            c_inc_ = (end - beg) / (1.0f - EXPF(curve_scalar_));
-        }
+	c_inc_ = (end - beg) / time_samps;
+    }
+    else
+    {
+	c_inc_ = (end - beg) / (1.0f - EXPF(curve_scalar_));
     }
 
     // update output
@@ -131,15 +128,17 @@ float AdEnv::Process()
     // Update Segment
     phase_ += 1;
     prev_segment_ = current_segment_;
-    if(phase_ > time_samps && current_segment_ != ADENV_SEG_IDLE)
+    if(current_segment_ != ADENV_SEG_IDLE)
     {
-        // Advance segment
-        current_segment_++;
-        // TODO: Add Cycling feature here.
-        if(current_segment_ > ADENV_SEG_DECAY)
-        {
-            current_segment_ = ADENV_SEG_IDLE;
-        }
+	if ((out >= 1.f && current_segment_ == ADENV_SEG_ATTACK) || (out <= 0.f && current_segment_ == ADENV_SEG_DECAY)){
+	    // Advance segment
+	    current_segment_++;
+	    // TODO: Add Cycling feature here.
+	    if(current_segment_ > ADENV_SEG_DECAY)
+	    {
+		current_segment_ = ADENV_SEG_IDLE;
+	    }
+	}
     }
     if(current_segment_ == ADENV_SEG_IDLE)
     {

--- a/modules/adenv.cpp
+++ b/modules/adenv.cpp
@@ -102,11 +102,11 @@ float AdEnv::Process()
     // This can happen only on transitions between curves
     if(curve_scalar_ == 0.0f)
     {
-	c_inc_ = (end - beg) / time_samps;
+        c_inc_ = (end - beg) / time_samps;
     }
     else
     {
-	c_inc_ = (end - beg) / (1.0f - EXPF(curve_scalar_));
+        c_inc_ = (end - beg) / (1.0f - EXPF(curve_scalar_));
     }
 
     // update output
@@ -130,15 +130,17 @@ float AdEnv::Process()
     prev_segment_ = current_segment_;
     if(current_segment_ != ADENV_SEG_IDLE)
     {
-	if ((out >= 1.f && current_segment_ == ADENV_SEG_ATTACK) || (out <= 0.f && current_segment_ == ADENV_SEG_DECAY)){
-	    // Advance segment
-	    current_segment_++;
-	    // TODO: Add Cycling feature here.
-	    if(current_segment_ > ADENV_SEG_DECAY)
-	    {
-		current_segment_ = ADENV_SEG_IDLE;
-	    }
-	}
+        if((out >= 1.f && current_segment_ == ADENV_SEG_ATTACK)
+           || (out <= 0.f && current_segment_ == ADENV_SEG_DECAY))
+        {
+            // Advance segment
+            current_segment_++;
+            // TODO: Add Cycling feature here.
+            if(current_segment_ > ADENV_SEG_DECAY)
+            {
+                current_segment_ = ADENV_SEG_IDLE;
+            }
+        }
     }
     if(current_segment_ == ADENV_SEG_IDLE)
     {


### PR DESCRIPTION
Calculates end of cycle based on output value rather than calculated segment time. Also allows for segments to be updated while they are playing, rather than between segments.