### PR TITLE
Compressor improvement

### DIFF
--- a/modules/compressor.cpp
+++ b/modules/compressor.cpp
@@ -3,20 +3,12 @@
 // Author: shensley, AvAars
 //
 
-//#include <math.h>
 #include <cmath>
 #include <stdlib.h>
 #include <stdint.h>
 #include "compressor.h"
-#include "dsp.h"
 
 using namespace daisysp;
-
-// From faust args are:
-// 0 - atk
-// 1 - ratio
-// 2 - rel
-// 3 - thresh
 
 #ifndef max
 #define max(a, b) ((a < b) ? b : a)
@@ -28,37 +20,32 @@ using namespace daisysp;
 
 void Compressor::Init(float sample_rate)
 {
-    sample_rate_     = min(192000, max(1, sample_rate));
-    sample_rate_inv_ = 1.0f / (float)sample_rate_;
-    sample_rate_inv2 = 2.0f / (float)sample_rate_;
-    
-	// Initializing the params in this order to avoid dividing by zero
+    sample_rate_      = min(192000, max(1, sample_rate));
+    sample_rate_inv_  = 1.0f / (float)sample_rate_;
+    sample_rate_inv2_ = 2.0f / (float)sample_rate_;
+
+    // Initializing the params in this order to avoid dividing by zero
 
     SetRatio(2.0f);
-	SetAttack(0.1f);
+    SetAttack(0.1f);
     SetRelease(0.1f);
     SetThreshold(-12.0f);
     AutoMakeup(true);
 
-    for(uint8_t i = 0; i < 2; i++)
-    {
-        gain_rec_[i]  = 0.1f;
-        slope_rec_[i] = 0.1f;
-    }
+    gain_rec_  = 0.1f;
+    slope_rec_ = 0.1f;
 }
 
 float Compressor::Process(float in)
 {
     float inAbs   = fabsf(in);
-    float cur_slo = ((slope_rec_[1] > inAbs) ? rel_slo_ : atk_slo_);
-    slope_rec_[0] = ((slope_rec_[1] * cur_slo) + ((1.0f - cur_slo) * inAbs));
-    gain_rec_[0]  = ((atk_slo2_ * gain_rec_[1])
-                    + (ratio_mul_
-                       * fmax(((20.f * log10(slope_rec_[0])) - thresh_), 0.f)));
-    gain_         = powf(10.0f, (0.05f * (gain_rec_[0] + makeup_gain_)));
+    float cur_slo = ((slope_rec_ > inAbs) ? rel_slo_ : atk_slo_);
+    slope_rec_    = ((slope_rec_ * cur_slo) + ((1.0f - cur_slo) * inAbs));
+    gain_rec_     = ((atk_slo2_ * gain_rec_)
+                 + (ratio_mul_
+                    * fmax(((20.f * fastlog10f(slope_rec_)) - thresh_), 0.f)));
+    gain_         = pow10f(0.05f * (gain_rec_ + makeup_gain_));
 
-    slope_rec_[1] = slope_rec_[0];
-    gain_rec_[1]  = gain_rec_[0];
     return gain_ * in;
 }
 
@@ -67,7 +54,7 @@ void Compressor::ProcessBlock(float *in, float *out, float *key, size_t size)
     for(size_t i = 0; i < size; i++)
     {
         Process(key[i]);
-        out[i] = GetGain(in[i]);
+        out[i] = Apply(in[i]);
     }
 }
 
@@ -83,7 +70,7 @@ void Compressor::ProcessBlock(float **in,
         Process(key[i]);
         for(size_t c = 0; c < channels; c++)
         {
-            out[c][i] = GetGain(in[c][i]);
+            out[c][i] = Apply(in[c][i]);
         }
     }
 }

--- a/modules/compressor.cpp
+++ b/modules/compressor.cpp
@@ -28,36 +28,37 @@ using namespace daisysp;
 
 void Compressor::Init(float sample_rate)
 {
-    sample_rate_ = min(192000.0f, max(1.0f, sample_rate));
-    sample_rate_inv_ = 1.0f / sample_rate_;
-    sample_rate_inv2 = 2.0f / sample_rate_;
-    // Skipped fHsliderN inits, but I'm going to init the 4 params
-    ratio_       = 2.0f;
-    thresh_      = -12.0f;
-    atk_         = 0.1f;
-    rel_         = 0.1f;
-    makeup_mul_ = 1.0f;
+    sample_rate_     = min(192000, max(1, sample_rate));
+    sample_rate_inv_ = 1.0f / (float)sample_rate_;
+    sample_rate_inv2 = 2.0f / (float)sample_rate_;
+    
+	// Initializing the params in this order to avoid dividing by zero
+
+    SetRatio(2.0f);
+	SetAttack(0.1f);
+    SetRelease(0.1f);
+    SetThreshold(-12.0f);
+    AutoMakeup(true);
+
     for(uint8_t i = 0; i < 2; i++)
     {
-        gain_rec_[i] = 0.1f;
+        gain_rec_[i]  = 0.1f;
         slope_rec_[i] = 0.1f;
     }
-    RecalculateSlopes();
 }
 
 float Compressor::Process(float in)
 {
-    float inAbs = fabsf(in);
+    float inAbs   = fabsf(in);
     float cur_slo = ((slope_rec_[1] > inAbs) ? rel_slo_ : atk_slo_);
-    slope_rec_[0]    = ((slope_rec_[1] * cur_slo) + ((1.0f - cur_slo) * inAbs));
-    gain_rec_[0]
-        = ((atk_slo2_ * gain_rec_[1])
-           + (ratio_mul_
-              * fmax(((20.f * log10(slope_rec_[0])) - thresh_), 0.f)));
-    gain_      = powf(10.0f, (0.05f * (gain_rec_[0] + makeup_gain_)));
+    slope_rec_[0] = ((slope_rec_[1] * cur_slo) + ((1.0f - cur_slo) * inAbs));
+    gain_rec_[0]  = ((atk_slo2_ * gain_rec_[1])
+                    + (ratio_mul_
+                       * fmax(((20.f * log10(slope_rec_[0])) - thresh_), 0.f)));
+    gain_         = powf(10.0f, (0.05f * (gain_rec_[0] + makeup_gain_)));
 
     slope_rec_[1] = slope_rec_[0];
-    gain_rec_[1] = gain_rec_[0];
+    gain_rec_[1]  = gain_rec_[0];
     return gain_ * in;
 }
 
@@ -85,16 +86,4 @@ void Compressor::ProcessBlock(float **in,
             out[c][i] = GetGain(in[c][i]);
         }
     }
-}
-
-void Compressor::RecalculateSlopes()
-{
-    makeup_gain_ = fabsf(thresh_ - thresh_ / ratio_) * 0.5f * makeup_mul_;
-
-    atk_slo_ = expf((-(sample_rate_inv_ / atk_)));
-
-    atk_slo2_  = expf(-(sample_rate_inv2 / atk_));
-    ratio_mul_ = ((1.0f - atk_slo2_) * ((1.0f / ratio_) - 1.0f));
-
-    rel_slo_ = expf(( - (sample_rate_inv_ / rel_)));
 }

--- a/modules/compressor.h
+++ b/modules/compressor.h
@@ -27,11 +27,12 @@ class Compressor
     Compressor() {}
     ~Compressor() {}
     /** Initializes compressor
-        sample_rate - rate at which samples will be produced by the audio engine.
+        \param sample_rate rate at which samples will be produced by the audio engine.
     */
     void Init(float sample_rate);
 
-    /** calculate the gain of the compressor, based on the key 
+    /** compress the audio input signal
+	    \param in audio input signal
     */
     float Process(float in);
 
@@ -40,8 +41,8 @@ class Compressor
     inline float GetGain(float in = 1.0f) { return gain_ * in; }
 
     /** compresses the audio input signal, keyed by a secondary input.
-        \param in - audio input signal (to be compressed)
-        \param key - audio input that will be used to side-chain the compressor. 
+        \param in audio input signal (to be compressed)
+        \param key audio input that will be used to side-chain the compressor. 
     */
     inline float Process(float in, float key)
     {
@@ -63,8 +64,8 @@ class Compressor
                       size_t  size);
 
 
-    /** amount of gain reduction applied to compressed signals
-        Expects 1.0 -> 40. (untested with values < 1.0)
+    /** Sets the amount of gain reduction applied to compressed signals
+        \param ratio Expects 1.0 -> 40. (untested with values < 1.0)
     */
     inline void SetRatio(float ratio)
     {
@@ -72,39 +73,45 @@ class Compressor
         RecalculateRatio();
     }
 
-    /** threshold in dB at which compression will be applied
-        Expects 0.0 -> -80.
+    /** Sets the threshold in dB at which compression will be applied
+        \param threshold Expects 0.0 -> -80.
     */
-    inline void SetThreshold(float thresh)
+    inline void SetThreshold(float threshold)
     {
-        thresh_ = thresh;
+        thresh_ = threshold;
         RecalculateMakeup();
     }
 
-    /** envelope time for onset of compression for signals above the threshold.
-        Expects 0.001 -> 10
+    /** Sets the envelope time for onset of compression for signals above the threshold.
+        \param attack Expects 0.001 -> 10
     */
-    inline void SetAttack(float atk)
+    inline void SetAttack(float attack)
     {
-        atk_ = atk;
+        atk_ = attack;
         RecalculateAttack();
     }
 
-    /** envelope time for release of compression as input signal falls below threshold.
-        Expects 0.001 -> 10
+    /** Sets the envelope time for release of compression as input signal falls below threshold.
+        \param release Expects 0.001 -> 10
     */
-    inline void SetRelease(float rel)
+    inline void SetRelease(float release)
     {
-        rel_     = rel;
+        rel_ = release;
         RecalculateRelease();
     }
 
+    /** Manually sets the additional gain to make up for the compression
+        \param gain Expects 0.0 -> 80
+    */
     inline void SetMakeup(float gain) { makeup_gain_ = gain; }
 
-    inline void AutoMakeup(bool makeup)
+    /** Enables or disables the automatic makeup gain. Disabling sets the makeup gain to 0.0
+        \param enable enable or disable
+    */
+    inline void AutoMakeup(bool enable)
     {
-        makeup_auto_ = makeup;
-        makeup_gain_  = 0.0f;
+        makeup_auto_ = enable;
+        makeup_gain_ = 0.0f;
         RecalculateMakeup();
     }
 

--- a/modules/compressor.h
+++ b/modules/compressor.h
@@ -42,7 +42,7 @@ class Compressor
         \param in audio input signal (to be compressed)
         \param key audio input that will be used to side-chain the compressor
     */
-    inline float Process(float in, float key)
+    float Process(float in, float key)
     {
         Process(key);
         return Apply(in);
@@ -51,14 +51,14 @@ class Compressor
     /** Apply compression to the audio signal, based on the previously calculated gain
 	    \param in audio input signal
     */
-    inline float Apply(float in) { return gain_ * in; }
+    float Apply(float in) { return gain_ * in; }
 
     /** Compresses a block of audio
         \param in audio input signal
         \param out audio output signal
         \param size the size of the block
     */
-    inline void ProcessBlock(float *in, float *out, size_t size)
+    void ProcessBlock(float *in, float *out, size_t size)
     {
         ProcessBlock(in, out, in, size);
     }
@@ -85,65 +85,65 @@ class Compressor
                       size_t  size);
 
     /** Gets the amount of gain reduction */
-    inline float GetRatio() { return ratio_; }
+    float GetRatio() { return ratio_; }
 
     /** Sets the amount of gain reduction applied to compressed signals
      \param ratio Expects 1.0 -> 40. (untested with values < 1.0)
     */
-    inline void SetRatio(float ratio)
+    void SetRatio(float ratio)
     {
         ratio_ = ratio;
         RecalculateRatio();
     }
 
     /** Gets the threshold in dB */
-    inline float GetThreshold() { return thresh_; }
+    float GetThreshold() { return thresh_; }
 
     /** Sets the threshold in dB at which compression will be applied
      \param threshold Expects 0.0 -> -80.
     */
-    inline void SetThreshold(float threshold)
+    void SetThreshold(float threshold)
     {
         thresh_ = threshold;
         RecalculateMakeup();
     }
 
     /** Gets the envelope time for onset of compression */
-    inline float GetAttack() { return atk_; }
+    float GetAttack() { return atk_; }
 
     /** Sets the envelope time for onset of compression for signals above the threshold.
         \param attack Expects 0.001 -> 10
     */
-    inline void SetAttack(float attack)
+    void SetAttack(float attack)
     {
         atk_ = attack;
         RecalculateAttack();
     }
 
     /** Gets the envelope time for release of compression */
-    inline float GetRelease() { return rel_; }
+    float GetRelease() { return rel_; }
 
     /** Sets the envelope time for release of compression as input signal falls below threshold.
         \param release Expects 0.001 -> 10
     */
-    inline void SetRelease(float release)
+    void SetRelease(float release)
     {
         rel_ = release;
         RecalculateRelease();
     }
 
     /** Gets the additional gain to make up for the compression */
-    inline float GetMakeup() { return makeup_gain_; }
+    float GetMakeup() { return makeup_gain_; }
 
     /** Manually sets the additional gain to make up for the compression
         \param gain Expects 0.0 -> 80
     */
-    inline void SetMakeup(float gain) { makeup_gain_ = gain; }
+    void SetMakeup(float gain) { makeup_gain_ = gain; }
 
     /** Enables or disables the automatic makeup gain. Disabling sets the makeup gain to 0.0
         \param enable true to enable, false to disable
     */
-    inline void AutoMakeup(bool enable)
+    void AutoMakeup(bool enable)
     {
         makeup_auto_ = enable;
         makeup_gain_ = 0.0f;
@@ -152,7 +152,7 @@ class Compressor
 
     /** Gets the gain reduction in dB
     */
-    inline float GetGain() { return fastlog10f(gain_) * 20.0f; }
+    float GetGain() { return fastlog10f(gain_) * 20.0f; }
 
   private:
     float ratio_, thresh_, atk_, rel_;
@@ -171,12 +171,13 @@ class Compressor
     // Auto makeup gain enable
     bool makeup_auto_;
 
-    inline void RecalculateRatio()
+    // Methods for recalculating internals
+    void RecalculateRatio()
     {
         ratio_mul_ = ((1.0f - atk_slo2_) * ((1.0f / ratio_) - 1.0f));
     }
 
-    inline void RecalculateAttack()
+    void RecalculateAttack()
     {
         atk_slo_  = expf(-(sample_rate_inv_ / atk_));
         atk_slo2_ = expf(-(sample_rate_inv2_ / atk_));
@@ -184,12 +185,9 @@ class Compressor
         RecalculateRatio();
     }
 
-    inline void RecalculateRelease()
-    {
-        rel_slo_ = expf((-(sample_rate_inv_ / rel_)));
-    }
+    void RecalculateRelease() { rel_slo_ = expf((-(sample_rate_inv_ / rel_))); }
 
-    inline void RecalculateMakeup()
+    void RecalculateMakeup()
     {
         if(makeup_auto_)
             makeup_gain_ = fabsf(thresh_ - thresh_ / ratio_) * 0.5f;

--- a/modules/compressor.h
+++ b/modules/compressor.h
@@ -18,9 +18,9 @@ Modifications made to do:
 - improved readability
 - improved makeup-gain calculations
 - changing controls now costs a lot less
+- a lot less expensive
 
 by: shensley, improved upon by AvAars
-\todo Still pretty expensive
 \todo Add soft/hard knee settings
 */
 class Compressor

--- a/modules/compressor.h
+++ b/modules/compressor.h
@@ -114,8 +114,8 @@ class Compressor
     float gain_;
     /** internals from faust struct
 */
-    float f_rec2_[2], f_rec1_[2], f_rec0_[2];
-    float atk_exp2_, ratio_mul_, atk_exp_, rel_exp_;
+    float slope_rec_[2], f_rec1_[2], gain_rec_[2];
+    float atk_slo2_, ratio_mul_, atk_slo_, rel_slo_;
     int   sample_rate_;
     float f_const0_, sample_rate_inv2, sample_rate_inv_;
 };

--- a/modules/compressor.h
+++ b/modules/compressor.h
@@ -96,6 +96,7 @@ class Compressor
     inline void SetRelease(float rel)
     {
         rel_     = rel;
+        RecalculateRelease();
     }
 
     inline void SetMakeup(float gain) { makeup_gain_ = gain; }
@@ -103,6 +104,7 @@ class Compressor
     inline void AutoMakeup(bool makeup)
     {
         makeup_auto_ = makeup;
+        makeup_gain_  = 0.0f;
         RecalculateMakeup();
     }
 

--- a/modules/dsp.h
+++ b/modules/dsp.h
@@ -17,7 +17,7 @@
 namespace daisysp
 {
 /** efficient floating point min/max
-c/o stephen mccaul 
+c/o stephen mccaul
 */
 inline float fmax(float a, float b)
 {
@@ -68,6 +68,38 @@ inline float fastroot(float f, int n)
     return f;
 }
 
+/** From http://openaudio.blogspot.com/2017/02/faster-log10-and-pow.html
+No approximation, pow10f(x) gives a 90% speed increase over powf(10.f, x)
+*/
+inline float pow10f(float f)
+{
+    return expf(2.302585092994046f * f);
+}
+
+/* Original code for fastlog2f by Dr. Paul Beckmann from the ARM community forum, adapted from the CMSIS-DSP library
+About 25% performance increase over std::log10f
+*/
+inline float fastlog2f(float f)
+{
+    float frac;
+    int   exp;
+    frac = frexpf(fabsf(f), &exp);
+    f    = 1.23149591368684f;
+    f *= frac;
+    f += -4.11852516267426f;
+    f *= frac;
+    f += 6.02197014179219f;
+    f *= frac;
+    f += -3.13396450166353f;
+    f += exp;
+    return (f);
+}
+
+inline float fastlog10f(float f)
+{
+    return fastlog2f(f) * 0.3010299956639812f;
+}
+
 /** Midi to frequency helper
 */
 inline float mtof(float m)
@@ -77,7 +109,7 @@ inline float mtof(float m)
 
 
 /** one pole lpf
-out is passed by reference, and must be retained between 
+out is passed by reference, and must be retained between
 calls to properly filter the signal
 coeff can be calculated:
 coeff = 1.0 / (time * sample_rate) ; where time is in seconds


### PR DESCRIPTION
Improved the compressor a lot, as this was one of the modules I currently use most. Would appreciate any feedback 👍 

Some changes I made:

- pulled gain calculation and reduction apart for monitoring and multichannel support (now has an Apply() function to apply gain reduction to a signal without calculating the reduction, and GetGain() to get the gain reduction in dB)
- improved readability by moving away from the faust internal names
- improved makeup-gain calculations (I _think_ this is correct, at least it sounds like that and this is based on another faust implementation, but I'm not _completely_ sure)
- changing parameters now costs a lot less (only calculating the affected internals on parameter changes)
- a lot less expensive, eliminating useless variables, more inlining and using pow10f and fastlog10f, which I have included in dsp.h
- added methods to disable automatic makeup gain and set your own makeup gain
- added getters for all parameters

And, as mentioned in #59 , added block processing (for single- and multichannel). The single sample process methods inside these block processing methods get fully inlined, so there's a performance gain for those using these methods.