### PR TITLE
Language Standards in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,11 @@ BIN = $(CP) -O binary -S
 #######################################
 # CFLAGS
 #######################################
+
+# language standards
+C_STD = -std=gnu11
+CPP_STD = -std=gnu++14
+
 # cpu
 CPU = -mcpu=cortex-m7
 
@@ -171,10 +176,10 @@ OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(ASM_SOURCES:.s=.o)))
 vpath %.s $(sort $(dir $(ASM_SOURCES)))
 
 $(BUILD_DIR)/%.o: %.c Makefile | $(BUILD_DIR)
-	$(CC) -c $(CFLAGS) -static -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.c=.lst)) $< -o $@
+	$(CC) -c $(CFLAGS) $(C_STD) -static -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.c=.lst)) $< -o $@
 
 $(BUILD_DIR)/%.o: %.cpp Makefile | $(BUILD_DIR)
-	$(CXX) -c $(CPPFLAGS) -static -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.cpp=.lst)) $< -o $@
+	$(CXX) -c $(CPPFLAGS) $(CPP_STD) -static -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.cpp=.lst)) $< -o $@
 
 $(BUILD_DIR)/%.o: %.s Makefile | $(BUILD_DIR)
 	$(AS) -c $(CFLAGS) $< -o $@


### PR DESCRIPTION
added language standards to Makefile instead of relying on compiler defaults.

Currently set to:

gnu11 for C
gnu++14 for C++


This resolves #32 

