### PR TITLE
use constants from dsp.h throughout the modules

### DIFF
--- a/modules/atone.cpp
+++ b/modules/atone.cpp
@@ -1,5 +1,6 @@
 #include "atone.h"
 #include <math.h>
+#include "dsp.h"
 
 using namespace daisysp;
 
@@ -25,7 +26,7 @@ void ATone::CalculateCoefficients()
 {
     float b, c2;
 
-    b   = 2.0f - cosf(2.0f * (float)M_PI * freq_ / sample_rate_);
+    b   = 2.0f - cosf(TWOPI_F * freq_ / sample_rate_);
     c2  = b - sqrtf(b * b - 1.0f);
     c2_ = c2;
 }

--- a/modules/balance.cpp
+++ b/modules/balance.cpp
@@ -1,5 +1,6 @@
 #include "balance.h"
 #include <math.h>
+#include "dsp.h"
 
 using namespace daisysp;
 
@@ -8,7 +9,7 @@ void Balance::Init(float sample_rate)
     float b;
     sample_rate_ = sample_rate;
     ihp_         = 10.0f;
-    b            = 2.0f - cosf(ihp_ * (2.0f * (float)M_PI / sample_rate_));
+    b            = 2.0f - cosf(ihp_ * (TWOPI_F / sample_rate_));
     c2_          = b - sqrtf(b * b - 1.0f);
     c1_          = 1.0f - c2_;
     prvq_ = prvr_ = prva_ = 0.0f;

--- a/modules/biquad.cpp
+++ b/modules/biquad.cpp
@@ -1,5 +1,6 @@
 #include "biquad.h"
 #include <math.h>
+#include "dsp.h"
 
 using namespace daisysp;
 
@@ -25,7 +26,7 @@ void Biquad::Reset()
 void Biquad::Init(float sample_rate)
 {
     sample_rate_ = sample_rate;
-    two_pi_d_sr_ = 2.0f * M_PI / sample_rate_;
+    two_pi_d_sr_ = TWOPI_F / sample_rate_;
 
     cutoff_ = 500;
     res_    = 0.7;

--- a/modules/crossfade.cpp
+++ b/modules/crossfade.cpp
@@ -1,5 +1,6 @@
 #include <math.h>
 #include "crossfade.h"
+#include "dsp.h"
 
 #define REALLYSMALLFLOAT 0.000001f
 
@@ -18,8 +19,8 @@ float CrossFade::Process(float &in1, float &in2)
             return (in1 * (1.0f - scalar_1)) + (in2 * scalar_1);
 
         case CROSSFADE_CPOW:
-            scalar_1 = sinf(pos_ * ((float)M_PI * 0.5f));
-            scalar_2 = sinf((1.0f - pos_) * ((float)M_PI * 0.5f));
+            scalar_1 = sinf(pos_ * HALFPI_F);
+            scalar_2 = sinf((1.0f - pos_) * HALFPI_F);
             return (in1 * scalar_2) + (in2 * scalar_1);
 
         case CROSSFADE_LOG:

--- a/modules/decimator.h
+++ b/modules/decimator.h
@@ -38,7 +38,7 @@ class Decimator
     inline void SetBitcrushFactor(float bitcrush_factor)
     {
         //            bitcrush_factor_ = bitcrush_factor;
-        bits_to_crush_ = bitcrush_factor * kMaxBitsToCrush;
+        bits_to_crush_ = (uint32_t)(bitcrush_factor * kMaxBitsToCrush);
     }
 
     /** Sets the exact number of bits to crush

--- a/modules/metro.cpp
+++ b/modules/metro.cpp
@@ -1,5 +1,6 @@
 #include <math.h>
 #include "metro.h"
+#include "dsp.h"
 
 using namespace daisysp;
 
@@ -8,15 +9,15 @@ void Metro::Init(float freq, float sample_rate)
     freq_        = freq;
     phs_         = 0.0f;
     sample_rate_ = sample_rate;
-    phs_inc_     = (2.0f * M_PI * freq_) / sample_rate_;
+    phs_inc_     = (TWOPI_F * freq_) / sample_rate_;
 }
 
 uint8_t Metro::Process()
 {
     phs_ += phs_inc_;
-    if(phs_ >= 2.0f * M_PI)
+    if(phs_ >= TWOPI_F)
     {
-        phs_ -= (2.0f * M_PI);
+        phs_ -= TWOPI_F;
         return 1;
     }
     return 0;
@@ -25,5 +26,5 @@ uint8_t Metro::Process()
 void Metro::SetFreq(float freq)
 {
     freq_    = freq;
-    phs_inc_ = (2.0f * M_PI * freq_) / sample_rate_;
+    phs_inc_ = (TWOPI_F * freq_) / sample_rate_;
 }

--- a/modules/phasor.cpp
+++ b/modules/phasor.cpp
@@ -1,24 +1,23 @@
 #include <math.h>
 #include "phasor.h"
+#include "dsp.h"
 
 using namespace daisysp;
-
-constexpr float TWO_PI_F = (float)(M_PI * 2.0);
 
 void Phasor::SetFreq(float freq)
 {
     freq_ = freq;
-    inc_  = (TWO_PI_F * freq_) / sample_rate_;
+    inc_  = (TWOPI_F * freq_) / sample_rate_;
 }
 
 float Phasor::Process()
 {
     float out;
-    out = phs_ / TWO_PI_F;
+    out = phs_ / TWOPI_F;
     phs_ += inc_;
-    if(phs_ > TWO_PI_F)
+    if(phs_ > TWOPI_F)
     {
-        phs_ -= TWO_PI_F;
+        phs_ -= TWOPI_F;
     }
     if(phs_ < 0.0f)
     {

--- a/modules/pitchshifter.h
+++ b/modules/pitchshifter.h
@@ -8,6 +8,7 @@
 #endif
 #include "delayline.h"
 #include "phasor.h"
+#include "dsp.h"
 
 /** Shift can be 30-100 ms lets just start with 50 for now.
 0.050 * SR = 2400 samples (at 48kHz)
@@ -69,7 +70,7 @@ class PitchShifter
         {
             gain_[i] = 0.0f;
             d_[i].Init();
-            phs_[i].Init(sr, 50, i == 0 ? 0 : (float)M_PI);
+            phs_[i].Init(sr, 50, i == 0 ? 0 : PI_F);
         }
         shift_up_ = true;
         del_size_ = SHIFT_BUFFER_SIZE;
@@ -114,8 +115,8 @@ class PitchShifter
         gain_[0] = arm_sin_f32(fade1 * (float)M_PI);
         gain_[1] = arm_sin_f32(fade2 * (float)M_PI);
 #else
-        gain_[0] = sinf(fade1 * (float)M_PI);
-        gain_[1] = sinf(fade2 * (float)M_PI);
+        gain_[0] = sinf(fade1 * PI_F);
+        gain_[1] = sinf(fade2 * PI_F);
 #endif
 
         // Handle Delay Writing
@@ -142,7 +143,7 @@ class PitchShifter
         if(transpose_ != transpose || force_recalc_)
         {
             transpose_ = transpose;
-            idx        = fabsf(transpose);
+            idx        = (uint8_t)fabsf(transpose);
             ratio      = semitone_ratios_[idx % 12];
             ratio *= (uint8_t)(fabsf(transpose) / 12) + 1;
             if(transpose > 0.0f)

--- a/modules/svf.cpp
+++ b/modules/svf.cpp
@@ -1,6 +1,6 @@
 #include <math.h>
 #include "svf.h"
-
+#include "dsp.h"
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
 using namespace daisysp;
@@ -67,7 +67,7 @@ void Svf::SetFreq(float f)
     }
     // Set Internal Frequency for fc_
     freq_ = 2.0f
-            * sinf((float)M_PI
+            * sinf(PI_F
                    * MIN(0.25f,
                          fc_ / (sr_ * 2.0f))); // fs*2 because double sampled
     // recalculate damp

--- a/modules/tone.cpp
+++ b/modules/tone.cpp
@@ -1,5 +1,6 @@
 #include "tone.h"
 #include <math.h>
+#include "dsp.h"
 
 using namespace daisysp;
 
@@ -25,7 +26,7 @@ float Tone::Process(float &in)
 void Tone::CalculateCoefficients()
 {
     float b, c1, c2;
-    b   = 2.0f - cosf(2.0f * (float)M_PI * freq_ / sample_rate_);
+    b   = 2.0f - cosf(TWOPI_F * freq_ / sample_rate_);
     c2  = b - sqrtf(b * b - 1.0f);
     c1  = 1.0f - c2;
     c1_ = c1;


### PR DESCRIPTION
Cosmetic consistency update.
All modules are updated to use math constants from dsp.h, such as 
PI_F, TWOPI_F, HALFPI_F, etc.
Also in several places implicit type casts were replaced by explicit ones to get rid of warnings.
