### PR TITLE
Svf fix

### DIFF
--- a/modules/dsp.h
+++ b/modules/dsp.h
@@ -192,6 +192,24 @@ inline float SoftClip(float x)
         return SoftLimit(x);
 }
 
+/** Quick check for Invalid float values (NaN, Inf, out of range) 
+ ** \param x value passed by reference, replaced by y if invalid. 
+ ** \param y value to replace x if invalidity is found. 
+ ** 
+ ** When DEBUG is true in the build, this will halt 
+ ** execution for tracing the reason for the invalidity. */
+inline void TestFloat(float &x, float y = 0.f)
+{
+    if(!isnormal(x) && x != 0)
+    {
+#ifdef DEBUG
+        asm("bkpt 255");
+#else
+        x = y;
+#endif
+    }
+}
+
 /** Based on soft saturate from:
 [musicdsp.org](musicdsp.org/en/latest/Effects/42-soft-saturation.html)
 Bram de Jong (2002-01-17)

--- a/modules/svf.cpp
+++ b/modules/svf.cpp
@@ -78,15 +78,9 @@ void Svf::SetFreq(float f)
 
 void Svf::SetRes(float r)
 {
-    if(r < 0.0f)
-    {
-        r = 0.0f;
-    }
-    else if(r > 1.0f)
-    {
-        r = 1.0f;
-    }
-    res_ = r;
+    res_ = fclamp(r, 0.f, 1.f);
+    res_ = res_ * .95f + .05f;
+
     // recalculate damp
     //damp = (MIN(2.0f * powf(res_, 0.25f), MIN(2.0f, 2.0f / freq - freq * 0.5f)));
     damp_ = MIN(2.0f * (1.0f - powf(res_, 0.25f)),

--- a/modules/svf.cpp
+++ b/modules/svf.cpp
@@ -24,6 +24,7 @@ void Svf::Init(float sample_rate)
     out_high_  = 0.0f;
     out_peak_  = 0.0f;
     out_band_  = 0.0f;
+    fc_max_    = sr_ / 3.f;
 }
 
 void Svf::Process(float in)
@@ -34,16 +35,18 @@ void Svf::Process(float in)
     low_       = low_ + freq_ * band_;
     high_      = notch_ - low_;
     band_      = freq_ * high_ + band_ - drive_ * band_ * band_ * band_;
+    // take first sample of output
     out_low_   = 0.5f * low_;
     out_high_  = 0.5f * high_;
     out_band_  = 0.5f * band_;
     out_peak_  = 0.5f * (low_ - high_);
     out_notch_ = 0.5f * notch_;
-    // second pass
+    // second pass 
     notch_ = input_ - damp_ * band_;
     low_   = low_ + freq_ * band_;
     high_  = notch_ - low_;
     band_  = freq_ * high_ + band_ - drive_ * band_ * band_ * band_;
+    // average second pass outputs 
     out_low_ += 0.5f * low_;
     out_high_ += 0.5f * high_;
     out_band_ += 0.5f * band_;
@@ -53,36 +56,30 @@ void Svf::Process(float in)
 
 void Svf::SetFreq(float f)
 {
-    if(f < 0.000001f)
-    {
-        fc_ = 0.000001f;
-    }
-    else if(f > sr_ / 2.0f)
-    {
-        fc_ = (sr_ / 2.0f) - 1.0f;
-    }
-    else
-    {
-        fc_ = f;
-    }
+    fc_ = fclamp(f, 1.0e-6, fc_max_);
     // Set Internal Frequency for fc_
     freq_ = 2.0f
             * sinf(PI_F
                    * MIN(0.25f,
                          fc_ / (sr_ * 2.0f))); // fs*2 because double sampled
     // recalculate damp
-    //damp = (MIN(2.0f * powf(res_, 0.25f), MIN(2.0f, 2.0f / freq - freq * 0.5f)));
-    damp_ = MIN(2.0f * (1.0f - powf(res_, 0.25f)),
+    damp_ = MIN(2.0f * (1.0f - pow(res_, 0.25f)),
                 MIN(2.0f, 2.0f / freq_ - freq_ * 0.5f));
 }
 
 void Svf::SetRes(float r)
 {
-    res_ = fclamp(r, 0.f, 1.f);
-    res_ = res_ * .95f + .05f;
-
+    float res = fclamp(r, 0.f, 1.f);
+    res_      = res;
     // recalculate damp
-    //damp = (MIN(2.0f * powf(res_, 0.25f), MIN(2.0f, 2.0f / freq - freq * 0.5f)));
-    damp_ = MIN(2.0f * (1.0f - powf(res_, 0.25f)),
+    damp_  = MIN(2.0f * (1.0f - pow(res_, 0.25f)),
                 MIN(2.0f, 2.0f / freq_ - freq_ * 0.5f));
+    drive_ = pre_drive_ * res_;
+}
+
+void Svf::SetDrive(float d)
+{
+    float drv  = fclamp(d * 0.1f, 0.f, 1.f);
+    pre_drive_ = drv;
+    drive_     = pre_drive_ * res_;
 }

--- a/modules/svf.cpp
+++ b/modules/svf.cpp
@@ -31,22 +31,22 @@ void Svf::Process(float in)
 {
     input_ = in;
     // first pass
-    notch_     = input_ - damp_ * band_;
-    low_       = low_ + freq_ * band_;
-    high_      = notch_ - low_;
-    band_      = freq_ * high_ + band_ - drive_ * band_ * band_ * band_;
+    notch_ = input_ - damp_ * band_;
+    low_   = low_ + freq_ * band_;
+    high_  = notch_ - low_;
+    band_  = freq_ * high_ + band_ - drive_ * band_ * band_ * band_;
     // take first sample of output
     out_low_   = 0.5f * low_;
     out_high_  = 0.5f * high_;
     out_band_  = 0.5f * band_;
     out_peak_  = 0.5f * (low_ - high_);
     out_notch_ = 0.5f * notch_;
-    // second pass 
+    // second pass
     notch_ = input_ - damp_ * band_;
     low_   = low_ + freq_ * band_;
     high_  = notch_ - low_;
     band_  = freq_ * high_ + band_ - drive_ * band_ * band_ * band_;
-    // average second pass outputs 
+    // average second pass outputs
     out_low_ += 0.5f * low_;
     out_high_ += 0.5f * high_;
     out_band_ += 0.5f * band_;

--- a/modules/svf.h
+++ b/modules/svf.h
@@ -33,7 +33,7 @@ class Svf
 
 
     /** sets the frequency of the cutoff frequency. 
-        f must be between 0.0 and sample_rate / 2
+        f must be between 0.0 and sample_rate / 3
     */
     void SetFreq(float f);
 

--- a/modules/svf.h
+++ b/modules/svf.h
@@ -45,7 +45,7 @@ class Svf
     /** sets the drive of the filter 
         affects the response of the resonance of the filter
     */
-    inline void SetDrive(float d) { drive_ = d; }
+    void SetDrive(float d);
     /** lowpass output
         \return low pass output of the filter
     */
@@ -72,6 +72,7 @@ class Svf
     float notch_, low_, high_, band_, peak_;
     float input_;
     float out_low_, out_high_, out_band_, out_peak_, out_notch_;
+    float pre_drive_, fc_max_;
 };
 } // namespace daisysp
 


### PR DESCRIPTION
Fixes the crashing bug by making resonance work internally from .05-1.
A better fix should be coming.
