### PR TITLE
VS build issue related to memset

### DIFF
--- a/modules/nlfilt.cpp
+++ b/modules/nlfilt.cpp
@@ -87,6 +87,9 @@ void NlFilt::ProcessBlock(float *in, float *out, size_t size)
 int32_t NlFilt::Set()
 {
     // Initializes delay buffer.
-    memset(delay_, 0, MAX_DELAY * sizeof(float)); // Memset
+    for(size_t i = 0; i < MAX_DELAY; i++)
+    {
+        delay_[i] = 0;
+    }
     return OK;
 }

--- a/modules/reverbsc.cpp
+++ b/modules/reverbsc.cpp
@@ -132,7 +132,10 @@ int ReverbSc::InitDelayLine(ReverbScDl *lp, int n)
     NextRandomLineseg(lp, n);
     /* clear delay line to zero */
     lp->filter_state = 0.0;
-    memset(lp->buf, 0, sizeof(float) * lp->buffer_size);
+    for(int i = 0; i < lp->buffer_size; i++)
+    {
+        lp->buf[i] = 0;
+    }
     return REVSC_OK;
 }
 


### PR DESCRIPTION
replaced memset with a loop to quell vs studio build error.

This actually seems like a bigger issue introduced when one of the recent modules was added. Since VS claims it can't find these, even when directly including `"string.h"` or `<cstring>` in the cpp file.

Could be another header guard duplicate as that did cause an issue before, but all of the examples are still building correctly so I find that unlikely.  Apparently this also popped up in #127 .

This at least temporarily resolves the build error.