### PR TITLE
Move reverb onto additional memory

### DIFF
--- a/Source/Effects/reverbsc.cpp
+++ b/Source/Effects/reverbsc.cpp
@@ -42,8 +42,10 @@ static int         DelayLineBytesAlloc(float sr, float i_pitch_mod, int n);
 static const float kOutputGain = 0.35;
 static const float kJpScale    = 0.25;
 
-int ReverbSc::Init(float sr)
+int ReverbSc::Init(float sr, float* buffer, size_t size)
 {
+    buffer_        = buffer;
+    size_          = size;
     i_sample_rate_ = sr;
     sample_rate_   = sr;
     feedback_      = 0.97;
@@ -53,13 +55,13 @@ int ReverbSc::Init(float sr)
     damp_fact_     = 1.0;
     prv_lpfreq_    = 0.0;
     init_done_     = 1;
-    int i, n_bytes = 0;
+    size_t i, n_bytes = 0;
     n_bytes = 0;
     for(i = 0; i < 8; i++)
     {
-        if(n_bytes > DSY_REVERBSC_MAX_SIZE)
+        if(n_bytes > size_)
             return 1;
-        delay_lines_[i].buf = (aux_) + n_bytes;
+        delay_lines_[i].buf = (buffer_) + n_bytes;
         InitDelayLine(&delay_lines_[i], i);
         n_bytes += DelayLineBytesAlloc(sr, 1, i);
     }

--- a/Source/Effects/reverbsc.cpp
+++ b/Source/Effects/reverbsc.cpp
@@ -42,7 +42,7 @@ static int         DelayLineBytesAlloc(float sr, float i_pitch_mod, int n);
 static const float kOutputGain = 0.35;
 static const float kJpScale    = 0.25;
 
-int ReverbSc::Init(float sr, float* buffer, size_t size)
+int ReverbSc::Init(float sr, float *buffer, size_t size)
 {
     buffer_        = buffer;
     size_          = size;

--- a/Source/Effects/reverbsc.h
+++ b/Source/Effects/reverbsc.h
@@ -42,7 +42,7 @@ class ReverbSc
     /** Initializes the reverb module, and sets the sample_rate at which the Process function will be called.
         Returns 0 if all good, or 1 if it runs out of delay times exceed maximum allowed.
     */
-    int Init(float sample_rate);
+    int Init(float sample_rate, float* buffer, size_t size);
 
     /** Process the input through the reverb, and updates values of out1, and out2 with the new processed signal.
     */
@@ -67,7 +67,8 @@ class ReverbSc
     float      prv_lpfreq_;
     int        init_done_;
     ReverbScDl delay_lines_[8];
-    float      aux_[DSY_REVERBSC_MAX_SIZE];
+    float*     buffer_;
+    size_t     size_;
 };
 
 

--- a/Source/Effects/reverbsc.h
+++ b/Source/Effects/reverbsc.h
@@ -42,7 +42,7 @@ class ReverbSc
     /** Initializes the reverb module, and sets the sample_rate at which the Process function will be called.
         Returns 0 if all good, or 1 if it runs out of delay times exceed maximum allowed.
     */
-    int Init(float sample_rate, float* buffer, size_t size);
+    int Init(float sample_rate, float *buffer, size_t size);
 
     /** Process the input through the reverb, and updates values of out1, and out2 with the new processed signal.
     */

--- a/Source/Effects/reverbsc.h
+++ b/Source/Effects/reverbsc.h
@@ -67,7 +67,7 @@ class ReverbSc
     float      prv_lpfreq_;
     int        init_done_;
     ReverbScDl delay_lines_[8];
-    float*     buffer_;
+    float *    buffer_;
     size_t     size_;
 };
 


### PR DESCRIPTION
I have been hitting different issues trying to use this reverb with a daisy patch where i run out of program memory. If there wasn't a particular reason that the buffer memory wasn't declared on the additional RAM, it seems like this change would be an improvement.

FWIW, this change is letting me run quad reverb in quad setups.