### PR TITLE
[CMake] Added missing files of phaser effect.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ Source/Effects/flanger.cpp
 Source/Effects/fold.cpp
 Source/Effects/overdrive.cpp
 Source/Effects/reverbsc.cpp
+Source/Effects/phaser.cpp
 Source/Effects/sampleratereducer.cpp
 Source/Effects/tremolo.cpp
 Source/Filters/allpass.cpp
@@ -82,6 +83,7 @@ Source/Effects/flanger.h
 Source/Effects/fold.h
 Source/Effects/overdrive.h
 Source/Effects/reverbsc.h
+Source/Effects/phaser.h
 Source/Effects/pitchshifter.h
 Source/Effects/sampleratereducer.h
 Source/Effects/tremolo.h


### PR DESCRIPTION
Hello, DaisySP team.

When I was developing my application, I found a problem that could not resolve a reference of `daisysp::Phaser` functions.
The reason for this is that adding the Phaser source code in CMake is forgotten.

Please check it.