### PR TITLE
Fixed missing __arm__ check before ARM assembly opcode

### DIFF
--- a/Source/Utility/dsp.h
+++ b/Source/Utility/dsp.h
@@ -206,7 +206,7 @@ inline void TestFloat(float &x, float y = 0.f)
 {
     if(!std::isnormal(x) && x != 0)
     {
-#ifdef __arm__ && DEBUG
+#if defined(__arm__) && defined(DEBUG)
         asm("bkpt 255");
 #else
         x = y;

--- a/Source/Utility/dsp.h
+++ b/Source/Utility/dsp.h
@@ -206,7 +206,7 @@ inline void TestFloat(float &x, float y = 0.f)
 {
     if(!std::isnormal(x) && x != 0)
     {
-#ifdef DEBUG
+#ifdef __arm__ && DEBUG
         asm("bkpt 255");
 #else
         x = y;


### PR DESCRIPTION
I was having some issues compiling DaisySP on Windows 10 with MSVC to use in conjunction with JUCE, and found that an ARM-specific opcode was being inserted into the dsp.h header file regardless of the platform. Simply checking if the \_\_arm\_\_ define is set fixes the issue.