### PR TITLE
Adsr remake

### DIFF
--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -7,22 +7,21 @@ using namespace daisysp;
 void Adsr::Init(float sample_rate, int blockSize)
 {
     sample_rate_ = sample_rate / blockSize;
-    SetTime(ADSR_SEG_ATTACK,  0.1f);
-    SetTime(ADSR_SEG_DECAY,   0.1f);
+    SetTime(ADSR_SEG_ATTACK, 0.1f);
+    SetTime(ADSR_SEG_DECAY, 0.1f);
     SetTime(ADSR_SEG_RELEASE, 0.1f);
-    sus_level_  = 0.7f;
-    x_          = 0.0f;
+    sus_level_ = 0.7f;
+    x_         = 0.0f;
 }
 
 void Adsr::Retrigger(bool hard)
 {
     mode_ = ADSR_SEG_ATTACK;
     if(hard)
-        x_ = 0.f;
+      x_ = 0.f;
 }
 
-void
-Adsr::SetTime(int seg, float time)
+void Adsr::SetTime(int seg, float time)
 {
     if(seg_time_[seg] != time)
     {
@@ -30,12 +29,13 @@ Adsr::SetTime(int seg, float time)
         if(time > 0.f)
         {
             const float attackTarget = logf(0.5f);
-            const float decayTarget  = logf(1./M_E);
-            float target = (seg == ADSR_SEG_ATTACK)? attackTarget : decayTarget;
-            seg_D0_  [seg] = 1.f - expf(target / (time * sample_rate_));
+            const float decayTarget  = logf(1. / M_E);
+            float       target
+                = (seg == ADSR_SEG_ATTACK) ? attackTarget : decayTarget;
+            seg_D0_[seg] = 1.f - expf(target / (time * sample_rate_));            
         }
         else
-            seg_D0_  [seg] = 1.f; // instant change
+            seg_D0_[seg] = 1.f; // instant change
     }
 }
 
@@ -50,7 +50,7 @@ float Adsr::Process(bool gate)
         mode_ = ADSR_SEG_RELEASE;
 
     float D0(seg_D0_[mode_]);
-    float target = mode_ == ADSR_SEG_DECAY? sus_level_ : - 0.1f;
+    float target = mode_ == ADSR_SEG_DECAY ? sus_level_ : - 0.1f;
     switch(mode_)
     {
         case ADSR_SEG_IDLE: out = 0.0f; break;
@@ -59,9 +59,8 @@ float Adsr::Process(bool gate)
             out = x_;
             if(out > 1.f)
             {
-                x_  =
-                out = 1.f;
-                mode_ = ADSR_SEG_DECAY;
+                x_  = out = 1.f;
+                mode_     = ADSR_SEG_DECAY;
             }
             break;
         case ADSR_SEG_DECAY:
@@ -70,9 +69,8 @@ float Adsr::Process(bool gate)
             out = x_;
             if(out < 0.0f)
             {
-                x_  =
-                out = 0.f;
-                mode_ = ADSR_SEG_IDLE;
+                x_ = out = 0.f;
+                mode_    = ADSR_SEG_IDLE;
             }
         default: break;
     }

--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -14,6 +14,13 @@ void Adsr::Init(float sample_rate, int blockSize)
     x_          = 0.0f;
 }
 
+void Adsr::Retrigger(bool hard)
+{
+    mode_ = ADSR_SEG_ATTACK;
+    if(hard)
+        x_ = 0.f;
+}
+
 void
 Adsr::SetTime(int seg, float time)
 {

--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -68,7 +68,7 @@ float Adsr::Process(bool gate)
         case ADSR_SEG_RELEASE:
             x_ += D0 * (target - x_);
             out = x_;
-            if(out <= 0.0f)
+            if(out < 0.0f)
             {
                 x_  =
                 out = 0.f;

--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -6,15 +6,10 @@ using namespace daisysp;
 
 void Adsr::Init(float sample_rate, int blockSize)
 {
-    sus_                 = 0.7f;
+    sample_rate_ = sample_rate / blockSize;
     SetTime(ADSR_SEG_ATTACK,  0.1f);
     SetTime(ADSR_SEG_DECAY,   0.1f);
     SetTime(ADSR_SEG_RELEASE, 0.1f);
-    a_           = 0.0f;
-    b_           = 0.0f;
-    x_           = 0.0f;
-    y_           = 0.0f;
-    sample_rate_ = sample_rate / blockSize;
     sus_level_  = 0.7f;
     x_          = 0.0f;
 }

--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -27,8 +27,13 @@ Adsr::SetTime(int seg, float time)
     if(seg_time_[seg] != time)
     {
         seg_time_[seg] = time;
-        float target = (seg == ADSR_SEG_ATTACK)? 0.5 : (1./M_E);
-        seg_D0_  [seg] = 1.f - expf(logf(target) / (time * sample_rate_));
+        if(time > 0.f)
+        {
+            float target = (seg == ADSR_SEG_ATTACK)? 0.5 : (1./M_E);
+            seg_D0_  [seg] = 1.f - expf(logf(target) / (time * sample_rate_));
+        }
+        else
+            seg_D0_  [seg] = 1.f; // instant change
     }
 }
 

--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -3,17 +3,6 @@
 
 using namespace daisysp;
 
-float Adsr::Tau2Pole(float tau)
-{
-    return expf(-1.0f / (tau * sample_rate_));
-}
-
-float Adsr::AdsrFilter()
-{
-    y_ = b_ * x_ + a_ * y_;
-    return y_;
-}
-
 
 void Adsr::Init(float sample_rate, int blockSize)
 {

--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -17,17 +17,28 @@ float Adsr::AdsrFilter()
 
 void Adsr::Init(float sample_rate, int blockSize)
 {
-    seg_time_[ADSR_SEG_ATTACK]  = 0.1f;
-    seg_time_[ADSR_SEG_DECAY]   = 0.1f;
-    sus_                        = 0.7f;
-    seg_time_[ADSR_SEG_RELEASE] = 0.1f;
-    //timer_ = 0;
+    sus_                 = 0.7f;
+    SetTime(ADSR_SEG_ATTACK,  0.1f);
+    SetTime(ADSR_SEG_DECAY,   0.1f);
+    SetTime(ADSR_SEG_RELEASE, 0.1f);
     a_           = 0.0f;
     b_           = 0.0f;
     x_           = 0.0f;
     y_           = 0.0f;
     sample_rate_ = sample_rate / blockSize;
 }
+
+void
+Adsr::SetTime(int seg, float time)
+{
+    if(seg_time_[seg] != time)
+    {
+        seg_time_[seg] = time;
+        float target = (seg == ADSR_SEG_ATTACK)? 0.5 : (1./M_E);
+        seg_D0_  [seg] = expf(logf(target) / (time * sample_rate_));
+    }
+}
+
 
 float Adsr::Process(bool gate)
 {

--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -26,8 +26,6 @@ void Adsr::Init(float sample_rate, int blockSize)
     b_           = 0.0f;
     x_           = 0.0f;
     y_           = 0.0f;
-    prev_        = 0.0f;
-    atk_time_    = seg_time_[ADSR_SEG_ATTACK] * sample_rate;
     sample_rate_ = sample_rate / blockSize;
 }
 
@@ -41,7 +39,6 @@ float Adsr::Process(bool gate)
         mode_ = ADSR_SEG_ATTACK;
         //timer_ = 0;
         pole      = Tau2Pole(seg_time_[ADSR_SEG_ATTACK] * 0.6f);
-        atk_time_ = seg_time_[ADSR_SEG_ATTACK] * sample_rate_;
         a_        = pole;
         b_        = 1.0f - pole;
     }
@@ -54,7 +51,6 @@ float Adsr::Process(bool gate)
     }
 
     x_    = (int)gate;
-    prev_ = (int)gate;
 
     switch(mode_)
     {

--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -15,7 +15,7 @@ float Adsr::AdsrFilter()
 }
 
 
-void Adsr::Init(float sample_rate)
+void Adsr::Init(float sample_rate, int blockSize)
 {
     seg_time_[ADSR_SEG_ATTACK]  = 0.1f;
     seg_time_[ADSR_SEG_DECAY]   = 0.1f;
@@ -28,7 +28,7 @@ void Adsr::Init(float sample_rate)
     y_           = 0.0f;
     prev_        = 0.0f;
     atk_time_    = seg_time_[ADSR_SEG_ATTACK] * sample_rate;
-    sample_rate_ = sample_rate;
+    sample_rate_ = sample_rate / blockSize;
 }
 
 float Adsr::Process(bool gate)

--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -15,6 +15,8 @@ void Adsr::Init(float sample_rate, int blockSize)
     x_           = 0.0f;
     y_           = 0.0f;
     sample_rate_ = sample_rate / blockSize;
+    sus_level_  = 0.7f;
+    x_          = 0.0f;
 }
 
 void
@@ -39,7 +41,7 @@ float Adsr::Process(bool gate)
         mode_ = ADSR_SEG_RELEASE;
 
     float D0(seg_D0_[mode_]);
-    float target = mode_ == ADSR_SEG_DECAY? sus_ : - 0.1f;
+    float target = mode_ == ADSR_SEG_DECAY? sus_level_ : - 0.1f;
     switch(mode_)
     {
         case ADSR_SEG_IDLE: out = 0.0f; break;

--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -29,8 +29,10 @@ Adsr::SetTime(int seg, float time)
         seg_time_[seg] = time;
         if(time > 0.f)
         {
-            float target = (seg == ADSR_SEG_ATTACK)? 0.5 : (1./M_E);
-            seg_D0_  [seg] = 1.f - expf(logf(target) / (time * sample_rate_));
+            const float attackTarget = logf(0.5f);
+            const float decayTarget  = logf(1./M_E);
+            float target = (seg == ADSR_SEG_ATTACK)? attackTarget : decayTarget;
+            seg_D0_  [seg] = 1.f - expf(target / (time * sample_rate_));
         }
         else
             seg_D0_  [seg] = 1.f; // instant change

--- a/Source/Control/adsr.cpp
+++ b/Source/Control/adsr.cpp
@@ -18,7 +18,7 @@ void Adsr::Retrigger(bool hard)
 {
     mode_ = ADSR_SEG_ATTACK;
     if(hard)
-      x_ = 0.f;
+        x_ = 0.f;
 }
 
 void Adsr::SetTime(int seg, float time)
@@ -32,7 +32,7 @@ void Adsr::SetTime(int seg, float time)
             const float decayTarget  = logf(1. / M_E);
             float       target
                 = (seg == ADSR_SEG_ATTACK) ? attackTarget : decayTarget;
-            seg_D0_[seg] = 1.f - expf(target / (time * sample_rate_));            
+            seg_D0_[seg] = 1.f - expf(target / (time * sample_rate_));
         }
         else
             seg_D0_[seg] = 1.f; // instant change
@@ -50,7 +50,7 @@ float Adsr::Process(bool gate)
         mode_ = ADSR_SEG_RELEASE;
 
     float D0(seg_D0_[mode_]);
-    float target = mode_ == ADSR_SEG_DECAY ? sus_level_ : - 0.1f;
+    float target = mode_ == ADSR_SEG_DECAY ? sus_level_ : -0.1f;
     switch(mode_)
     {
         case ADSR_SEG_IDLE: out = 0.0f; break;
@@ -59,8 +59,8 @@ float Adsr::Process(bool gate)
             out = x_;
             if(out > 1.f)
             {
-                x_  = out = 1.f;
-                mode_     = ADSR_SEG_DECAY;
+                x_ = out = 1.f;
+                mode_    = ADSR_SEG_DECAY;
             }
             break;
         case ADSR_SEG_DECAY:

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -43,20 +43,15 @@ class Adsr
         \param sample_rate - The sample rate of the audio engine being run. 
     */
     void Init(float sample_rate, int blockSize = 1);
-
     /**
      \function Retrigger forces the envelope back to attack phase
      \param hard  resets the history to zero, results in a click.
      */
-    
     void Retrigger(bool hard);
-    
     /** Processes one sample through the filter and returns one sample.
         \param gate - trigger the envelope, hold it to sustain 
     */
-    
     float Process(bool gate);
-
     /** Sets time
         Set time per segment in seconds
     */
@@ -66,8 +61,9 @@ class Adsr
     */
     inline void SetSustainLevel(float sus_level)
     {
-        sus_level
-            = (sus_level < 0.f) ? 0.f : (sus_level > 1.f) ? 1.f : sus_level;
+        sus_level  = (sus_level < 0.f)   ? 0.f
+                     : (sus_level > 1.f) ? 1.f
+                                         : sus_level;
         sus_level_ = sus_level;
     }
     /** get the current envelope segment
@@ -80,10 +76,10 @@ class Adsr
     inline bool IsRunning() const { return mode_ != ADSR_SEG_IDLE; }
 
   private:
-    float sus_level_{0.f};
-    float x_{0.f};
-    float seg_time_[ADSR_SEG_LAST]{0.f};
-    float seg_D0_[ADSR_SEG_LAST]{0.f};
+    float   sus_level_{0.f};
+    float   x_{0.f};
+    float   seg_time_[ADSR_SEG_LAST]{0.f};
+    float   seg_D0_[ADSR_SEG_LAST]{0.f};
     int     sample_rate_;
     uint8_t mode_;
 };

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -40,7 +40,7 @@ class Adsr
     /** Initializes the Adsr module.
         \param sample_rate - The sample rate of the audio engine being run. 
     */
-    void Init(float sample_rate);
+    void Init(float sample_rate, int blockSize = 1);
 
 
     /** Processes one sample through the filter and returns one sample.

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -72,8 +72,6 @@ class Adsr
             a_, b_, y_, x_;
     int     sample_rate_;
     uint8_t mode_;
-    float   Tau2Pole(float tau);
-    float   AdsrFilter();
 };
 } // namespace daisysp
 #endif

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -65,9 +65,8 @@ class Adsr
     */
     inline void SetSustainLevel(float sus_level)
     {
-        sus_level  = (sus_level <= 0.f)  ? -0.01f // forces envelope into idle
-                     : (sus_level > 1.f) ? 1.f
-                                         : sus_level;
+        sus_level = (sus_level <= 0.f) ? -0.01f // forces envelope into idle
+                                       : (sus_level > 1.f) ? 1.f : sus_level;
         sus_level_ = sus_level;
     }
     /** get the current envelope segment

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -37,7 +37,7 @@ Remake by Steffan DIedrichsen, May 2021
 class Adsr
 {
   public:
-    Adsr () {}
+    Adsr() {}
     ~Adsr() {}
     /** Initializes the Adsr module.
         \param sample_rate - The sample rate of the audio engine being run. 
@@ -49,7 +49,7 @@ class Adsr
      \param hard  resets the hosrory to zero, results in a click.
      */
     
-    void  Retrigger(bool hard);
+    void Retrigger(bool hard);
 
     
     /** Processes one sample through the filter and returns one sample.
@@ -67,7 +67,8 @@ class Adsr
     */
     inline void SetSustainLevel(float sus_level)
     {
-        sus_level = (sus_level < 0.f)? 0.f : (sus_level > 1.f)? 1.f : sus_level;
+        sus_level
+            = (sus_level < 0.f) ? 0.f : (sus_level > 1.f) ? 1.f : sus_level;
         sus_level_ = sus_level;
     }
     /** get the current envelope segment
@@ -80,10 +81,10 @@ class Adsr
     inline bool IsRunning() const { return mode_ != ADSR_SEG_IDLE; }
 
   private:
-    float   sus_level_,
-            seg_time_[ADSR_SEG_LAST]{0.f},
-            seg_D0_[ADSR_SEG_LAST]{0.f},
-            x_;
+    float   sus_level_{0.f};
+    float   seg_time_[ADSR_SEG_LAST]{0.f};
+    float   seg_D0_[ADSR_SEG_LAST]{0.f},
+    float   x_{0.f};
     int     sample_rate_;
     uint8_t mode_;
 };

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -42,6 +42,12 @@ class Adsr
     */
     void Init(float sample_rate, int blockSize = 1);
 
+    /**
+     \function Retrigger forces the envelope back to attack phase
+     \param hard  resets the hosrory to zero, results in a click.
+     */
+    
+    void  Retrigger(bool hard);
 
     /** Processes one sample through the filter and returns one sample.
         \param gate - trigger the envelope, hold it to sustain 

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -81,8 +81,9 @@ class Adsr
 
   private:
     float sus_level_{0.f};
+    float x_{0.f};
     float seg_time_[ADSR_SEG_LAST]{0.f};
-    float seg_D0_[ADSR_SEG_LAST]{0.f}, float x_{0.f};
+    float seg_D0_[ADSR_SEG_LAST]{0.f};
     int     sample_rate_;
     uint8_t mode_;
 };

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -80,10 +80,9 @@ class Adsr
     inline bool IsRunning() const { return mode_ != ADSR_SEG_IDLE; }
 
   private:
-    float   sus_level_{0.f};
-    float   seg_time_[ADSR_SEG_LAST]{0.f};
-    float   seg_D0_[ADSR_SEG_LAST]{0.f},
-    float   x_{0.f};
+    float sus_level_{0.f};
+    float seg_time_[ADSR_SEG_LAST]{0.f};
+    float seg_D0_[ADSR_SEG_LAST]{0.f}, float x_{0.f};
     int     sample_rate_;
     uint8_t mode_;
 };

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -66,7 +66,7 @@ class Adsr
     inline bool IsRunning() const { return mode_ != ADSR_SEG_IDLE; }
 
   private:
-    float   sus_, seg_time_[ADSR_SEG_LAST], a_, b_, y_, x_, prev_, atk_time_;
+    float   sus_, seg_time_[ADSR_SEG_LAST], a_, b_, y_, x_;
     int     sample_rate_;
     uint8_t mode_;
     float   Tau2Pole(float tau);

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -11,18 +11,14 @@ namespace daisysp
 - IDLE   = located at phase location 0, and not currently running
 - ATTACK  = First segment of envelope where phase moves from 0 to 1
 - DECAY   = Second segment of envelope where phase moves from 1 to SUSTAIN value
-- SUSTAIN = Third segment of envelope, stays at SUSTAIN level until GATE is released
 - RELEASE =     Fourth segment of envelop where phase moves from SUSTAIN to 0
-- LAST    =  Last segment, aka release
 */
 enum
 {
-    ADSR_SEG_IDLE,
-    ADSR_SEG_ATTACK,
-    ADSR_SEG_DECAY,
-    ADSR_SEG_SUSTAIN,
-    ADSR_SEG_RELEASE,
-    ADSR_SEG_LAST,
+    ADSR_SEG_IDLE    = 0,
+    ADSR_SEG_ATTACK  = 1,
+    ADSR_SEG_DECAY   = 2,
+    ADSR_SEG_RELEASE = 4
 };
 
 
@@ -56,13 +52,22 @@ class Adsr
         Set time per segment in seconds
     */
     void SetTime(int seg, float time);
+    void SetAttackTime(float timeInS, float shape = 0.0f);
+    void SetDecayTime(float timeInS);
+    void SetReleaseTime(float timeInS);
+
+  private:
+    void SetTimeConstant(float timeInS, float& time, float& coeff);
+
+  public:
     /** Sustain level
         \param sus_level - sets sustain level, 0...1.0
     */
     inline void SetSustainLevel(float sus_level)
     {
-        sus_level
-            = (sus_level < 0.f) ? 0.f : (sus_level > 1.f) ? 1.f : sus_level;
+        sus_level  = (sus_level <= 0.f)  ? -0.01f // forces envelope into idle
+                     : (sus_level > 1.f) ? 1.f
+                                         : sus_level;
         sus_level_ = sus_level;
     }
     /** get the current envelope segment
@@ -77,10 +82,17 @@ class Adsr
   private:
     float   sus_level_{0.f};
     float   x_{0.f};
-    float   seg_time_[ADSR_SEG_LAST]{0.f};
-    float   seg_D0_[ADSR_SEG_LAST]{0.f};
+    float   attackShape_{-1.f};
+    float   attackTarget_{0.0f};
+    float   attackTime_{-1.0f};
+    float   decayTime_{-1.0f};
+    float   releaseTime_{-1.0f};
+    float   attackD0_{0.f};
+    float   decayD0_{0.f};
+    float   releaseD0_{0.f};
     int     sample_rate_;
-    uint8_t mode_;
+    uint8_t mode_{ADSR_SEG_IDLE};
+    bool    gate_{false};
 };
 } // namespace daisysp
 #endif

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -59,7 +59,7 @@ class Adsr
     /** Sets time
         Set time per segment in seconds
     */
-    inline void SetTime(int seg, float time);
+    void SetTime(int seg, float time);
     /** Sustain level
         \param sus_level - sets sustain level, 0...1.0
     */

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -61,9 +61,8 @@ class Adsr
     */
     inline void SetSustainLevel(float sus_level)
     {
-        sus_level  = (sus_level < 0.f)   ? 0.f
-                     : (sus_level > 1.f) ? 1.f
-                                         : sus_level;
+        sus_level           
+            = (sus_level < 0.f) ? 0.f : (sus_level > 1.f) ? 1.f : sus_level;        
         sus_level_ = sus_level;
     }
     /** get the current envelope segment

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -46,11 +46,10 @@ class Adsr
 
     /**
      \function Retrigger forces the envelope back to attack phase
-     \param hard  resets the hosrory to zero, results in a click.
+     \param hard  resets the history to zero, results in a click.
      */
     
     void Retrigger(bool hard);
-
     
     /** Processes one sample through the filter and returns one sample.
         \param gate - trigger the envelope, hold it to sustain 

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -53,9 +53,13 @@ class Adsr
     */
     inline void SetTime(int seg, float time);
     /** Sustain level
-        \param sus_level - sets sustain level
+        \param sus_level - sets sustain level, 0...1.0
     */
-    inline void SetSustainLevel(float sus_level) { sus_ = sus_level; }
+    inline void SetSustainLevel(float sus_level)
+    {
+        sus_level = (sus_level < 0.f)? 0.f : (sus_level > 1.f)? 1.f : sus_level;
+        sus_level_ = sus_level;
+    }
     /** get the current envelope segment
         \return the segment of the envelope that the phase is currently located in.
     */
@@ -66,7 +70,7 @@ class Adsr
     inline bool IsRunning() const { return mode_ != ADSR_SEG_IDLE; }
 
   private:
-    float   sus_,
+    float   sus_level_,
             seg_time_[ADSR_SEG_LAST]{0.f},
             seg_D0_[ADSR_SEG_LAST]{0.f},
             a_, b_, y_, x_;

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -51,7 +51,7 @@ class Adsr
     /** Sets time
         Set time per segment in seconds
     */
-    inline void SetTime(int seg, float time) { seg_time_[seg] = time; }
+    inline void SetTime(int seg, float time);
     /** Sustain level
         \param sus_level - sets sustain level
     */
@@ -66,7 +66,10 @@ class Adsr
     inline bool IsRunning() const { return mode_ != ADSR_SEG_IDLE; }
 
   private:
-    float   sus_, seg_time_[ADSR_SEG_LAST], a_, b_, y_, x_;
+    float   sus_,
+            seg_time_[ADSR_SEG_LAST]{0.f},
+            seg_D0_[ADSR_SEG_LAST]{0.f},
+            a_, b_, y_, x_;
     int     sample_rate_;
     uint8_t mode_;
     float   Tau2Pole(float tau);

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -31,6 +31,8 @@ enum
 Original author(s) : Paul Batchelor
 
 Ported from Soundpipe by Ben Sergentanis, May 2020
+ 
+Remake by Steffan DIedrichsen, May 2021
 */
 class Adsr
 {

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -35,7 +35,7 @@ Ported from Soundpipe by Ben Sergentanis, May 2020
 class Adsr
 {
   public:
-    Adsr() {}
+    Adsr () {}
     ~Adsr() {}
     /** Initializes the Adsr module.
         \param sample_rate - The sample rate of the audio engine being run. 
@@ -49,9 +49,11 @@ class Adsr
     
     void  Retrigger(bool hard);
 
+    
     /** Processes one sample through the filter and returns one sample.
         \param gate - trigger the envelope, hold it to sustain 
     */
+    
     float Process(bool gate);
 
     /** Sets time

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -73,7 +73,7 @@ class Adsr
     float   sus_level_,
             seg_time_[ADSR_SEG_LAST]{0.f},
             seg_D0_[ADSR_SEG_LAST]{0.f},
-            a_, b_, y_, x_;
+            x_;
     int     sample_rate_;
     uint8_t mode_;
 };

--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -61,8 +61,8 @@ class Adsr
     */
     inline void SetSustainLevel(float sus_level)
     {
-        sus_level           
-            = (sus_level < 0.f) ? 0.f : (sus_level > 1.f) ? 1.f : sus_level;        
+        sus_level
+            = (sus_level < 0.f) ? 0.f : (sus_level > 1.f) ? 1.f : sus_level;
         sus_level_ = sus_level;
     }
     /** get the current envelope segment


### PR DESCRIPTION
That's a much leaner version of the envelope based on a first order SVF.
Improvements:
- exact attack time
- exact decay time for 1/e target value @ sustain = 0.f;
- no residual output
- added Retrigger
- no time constant calculation on every process call
- Init() takes a block size argument, which us useful for processing control elements only once per audio call back. 