### PR TITLE
Update adsr.h

### DIFF
--- a/Source/Control/adsr.h
+++ b/Source/Control/adsr.h
@@ -65,7 +65,7 @@ class Adsr
     */
     inline void SetSustainLevel(float sus_level)
     {
-        sus_level = (sus_level <= 0.f) ? -0.01f // forces envelope into idle
+        sus_level = (sus_level < 0.f) ? -0.01f // forces envelope into idle
                                        : (sus_level > 1.f) ? 1.f : sus_level;
         sus_level_ = sus_level;
     }


### PR DESCRIPTION
  changed line 68 from    sus_level <= 0.f   to  sus_level < 0.f.  This prevents the envelope from locking down indefinitely when a note is held down. 
I believe this is an old bug thats crept back in.