### PR TITLE
Fix/pitch shift

### DIFF
--- a/Source/Control/phasor.cpp
+++ b/Source/Control/phasor.cpp
@@ -21,7 +21,7 @@ float Phasor::Process()
     }
     if(phs_ < 0.0f)
     {
-        phs_ = 0.0f;
+        phs_ += TWOPI_F;
     }
     return out;
 }

--- a/Source/Effects/pitchshifter.h
+++ b/Source/Effects/pitchshifter.h
@@ -10,13 +10,6 @@
 #include "Utility/delayline.h"
 #include "Control/phasor.h"
 
-/** Shift can be 30-100 ms lets just start with 50 for now.
-0.050 * SR = 2400 samples (at 48kHz)
-*/
-#define SHIFT_BUFFER_SIZE 16384
-//#define SHIFT_BUFFER_SIZE 4800
-//#define SHIFT_BUFFER_SIZE 8192
-//#define SHIFT_BUFFER_SIZE 1024
 
 namespace daisysp
 {
@@ -49,7 +42,7 @@ where:
     r is the sample_rate
 
 solving for t = 12.0
-f = (12 - 1) * 48000 / SHIFT_BUFFER_SIZE;
+f = (12 - 1) * 48000 / kShiftDelaySize;
 
 \todo - move hash_xs32 and myrand to dsp.h and give appropriate names
 */
@@ -58,24 +51,22 @@ class PitchShifter
   public:
     PitchShifter() {}
     ~PitchShifter() {}
-    /** Initialize pitch shifter
-    */
-    void Init(float sr)
+    /** Initialize pitch shifter */
+    void Init(float sr, bool quantize_semitones = true)
     {
         force_recalc_ = false;
         sr_           = sr;
         mod_freq_     = 5.0f;
-        SetSemitones();
         for(uint8_t i = 0; i < 2; i++)
         {
             gain_[i] = 0.0f;
             d_[i].Init();
             phs_[i].Init(sr, 50, i == 0 ? 0 : PI_F);
         }
-        shift_up_ = true;
-        del_size_ = SHIFT_BUFFER_SIZE;
+        del_size_ = kShiftDelaySize;
         SetDelSize(del_size_);
-        fun_ = 0.0f;
+        fun_                = 0.0f;
+        quantize_semitones_ = quantize_semitones;
     }
 
     /** process pitch shifter
@@ -104,13 +95,10 @@ class PitchShifter
         slewed_mod_[1] += mod_coeff_[1] * (mod_b_amt_ - slewed_mod_[1]);
         prev_phs_a_ = fade1;
         prev_phs_b_ = fade2;
-        if(shift_up_)
-        {
-            fade1 = 1.0f - fade1;
-            fade2 = 1.0f - fade2;
-        }
-        mod_[0] = fade1 * (del_size_ - 1);
-        mod_[1] = fade2 * (del_size_ - 1);
+        fade1       = 1.0f - fade1;
+        fade2       = 1.0f - fade2;
+        mod_[0]     = fade1 * (del_size_ - 1);
+        mod_[1]     = fade2 * (del_size_ - 1);
 #ifdef USE_ARM_DSP
         gain_[0] = arm_sin_f32(fade1 * (float)M_PI);
         gain_[1] = arm_sin_f32(fade2 * (float)M_PI);
@@ -138,27 +126,12 @@ class PitchShifter
     */
     void SetTransposition(const float &transpose)
     {
-        float   ratio;
-        uint8_t idx;
+        float ratio;
         if(transpose_ != transpose || force_recalc_)
         {
-            transpose_ = transpose;
-            idx        = (uint8_t)fabsf(transpose);
-            ratio      = semitone_ratios_[idx % 12];
-            ratio *= (uint8_t)(fabsf(transpose) / 12) + 1;
-            if(transpose > 0.0f)
-            {
-                shift_up_ = true;
-            }
-            else
-            {
-                shift_up_ = false;
-            }
-            mod_freq_ = ((ratio - 1.0f) * sr_) / del_size_;
-            if(mod_freq_ < 0.0f)
-            {
-                mod_freq_ = 0.0f;
-            }
+            transpose_ = quantize_semitones_ ? (int32_t)transpose : transpose;
+            ratio      = pow(2.f, transpose_ / 12.f);
+            mod_freq_  = ((ratio - 1.0f) * sr_) / del_size_;
             phs_[0].SetFreq(mod_freq_);
             phs_[1].SetFreq(mod_freq_);
             if(force_recalc_)
@@ -172,7 +145,7 @@ class PitchShifter
     */
     void SetDelSize(uint32_t size)
     {
-        del_size_     = size < SHIFT_BUFFER_SIZE ? size : SHIFT_BUFFER_SIZE;
+        del_size_     = size < kShiftDelaySize ? size : kShiftDelaySize;
         force_recalc_ = true;
         SetTransposition(transpose_);
     }
@@ -182,29 +155,23 @@ class PitchShifter
     inline void SetFun(float f) { fun_ = f; }
 
   private:
-    inline void SetSemitones()
-    {
-        for(size_t i = 0; i < 12; i++)
-        {
-            semitone_ratios_[i] = powf(2.0f, (float)i / 12);
-        }
-    }
-    typedef DelayLine<float, SHIFT_BUFFER_SIZE> ShiftDelay;
-    ShiftDelay                                  d_[2];
-    float                                       pitch_shift_, mod_freq_;
-    uint32_t                                    del_size_;
-    /** lfo stuff
-*/
+    /** Shift can be 30-100 ms lets just start with 50 for now.
+    0.050 * SR = 2400 samples (at 48kHz) */
+    static constexpr size_t                   kShiftDelaySize = 16384;
+    typedef DelayLine<float, kShiftDelaySize> ShiftDelay;
+    ShiftDelay                                d_[2];
+    float                                     pitch_shift_, mod_freq_;
+    uint32_t                                  del_size_;
+    /** lfo stuff */
     bool   force_recalc_;
     float  sr_;
-    bool   shift_up_;
     Phasor phs_[2];
     float  gain_[2], mod_[2], transpose_;
     float  fun_, mod_a_amt_, mod_b_amt_, prev_phs_a_, prev_phs_b_;
     float  slewed_mod_[2], mod_coeff_[2];
-    /** pitch stuff
-*/
-    float semitone_ratios_[12];
+
+    /** Config stuff */
+    bool quantize_semitones_;
 };
 } // namespace daisysp
 

--- a/Source/Effects/pitchshifter.h
+++ b/Source/Effects/pitchshifter.h
@@ -51,8 +51,13 @@ class PitchShifter
   public:
     PitchShifter() {}
     ~PitchShifter() {}
-    /** Initialize pitch shifter */
-    void Init(float sr, bool quantize_semitones = true)
+
+
+    /** Initialize pitch shifter 
+     *  \param sr the expected samplerate in Hz of the audio engines
+     *  \param quantize_semitones locks transpositions to integer values (defaults to false)
+    */
+    void Init(float sr, bool quantize_semitones = false)
     {
         force_recalc_ = false;
         sr_           = sr;


### PR DESCRIPTION
This should end up fixing #162 

The negative transposition was almost 2x the ratio that it was supposed to. So that none of the semitones were accurate when set below 0. This has been fixed.

Making the phasor accept negative frequency let's us remove any of the weird "is it going up or down" logic, and just have the phasor flip when the ratio is derived from a negative transposition.

This does remove the pre-generated lookup for the semitones. We can replace it with a more robust lut at some point to get this to be a bit more efficient.

Also moved the one global define into the class as a member constexpr

And added a secondary argument (defaulting to false) to lock transpositions to semitones.
