### PR TITLE
Looper - Updated Frip Decay value to use explicit value instead of sin constexpr

### DIFF
--- a/Source/Utility/looper.h
+++ b/Source/Utility/looper.h
@@ -59,9 +59,9 @@ class Looper
         float inc;
         bool  hitloop = false;
         // Record forward at normal speed during the first loop no matter what.
-        inc  = state_ == State::EMPTY || state_ == State::REC_FIRST
-                   ? 1.f
-                   : GetIncrementSize();
+        inc = state_ == State::EMPTY || state_ == State::REC_FIRST
+                  ? 1.f
+                  : GetIncrementSize();
         win_ = WindowVal(win_idx_ * kWindowFactor);
         switch(state_)
         {

--- a/Source/Utility/looper.h
+++ b/Source/Utility/looper.h
@@ -59,9 +59,9 @@ class Looper
         float inc;
         bool  hitloop = false;
         // Record forward at normal speed during the first loop no matter what.
-        inc = state_ == State::EMPTY || state_ == State::REC_FIRST
-                  ? 1.f
-                  : GetIncrementSize();
+        inc  = state_ == State::EMPTY || state_ == State::REC_FIRST
+                   ? 1.f
+                   : GetIncrementSize();
         win_ = WindowVal(win_idx_ * kWindowFactor);
         switch(state_)
         {
@@ -223,7 +223,9 @@ class Looper
 
   private:
     /** Constants */
-    static constexpr float kFripDecayVal      = std::sin(PI_F / 4.f);
+
+    /** Decay value for frippertronics mode is sin(PI / 4) */
+    static constexpr float kFripDecayVal      = 0.7071067811865476f;
     static constexpr int   kNumModes          = 4;
     static constexpr int   kNumPlaybackSpeeds = 3;
     static constexpr int   kWindowSamps       = 1200;


### PR DESCRIPTION
fixes #169 - change constant value for frip decay from std::sin to fixed value.