### PR TITLE
Add pulse width setting to Oscillator class for square waveforms

### DIFF
--- a/Source/Synthesis/oscillator.cpp
+++ b/Source/Synthesis/oscillator.cpp
@@ -20,7 +20,7 @@ float Oscillator::Process()
             out = -1.0f * (((phase_ * TWO_PI_RECIP * 2.0f)) - 1.0f);
             break;
         case WAVE_RAMP: out = ((phase_ * TWO_PI_RECIP * 2.0f)) - 1.0f; break;
-        case WAVE_SQUARE: out = phase_ < pw_ ? (1.0f) : -1.0f; break;
+        case WAVE_SQUARE: out = phase_ < pw_rad_ ? (1.0f) : -1.0f; break;
         case WAVE_POLYBLEP_TRI:
             t   = phase_ * TWO_PI_RECIP;
             out = phase_ < PI_F ? 1.0f : -1.0f;
@@ -39,9 +39,9 @@ float Oscillator::Process()
             break;
         case WAVE_POLYBLEP_SQUARE:
             t   = phase_ * TWO_PI_RECIP;
-            out = phase_ < PI_F ? 1.0f : -1.0f;
+            out = phase_ < pw_rad_ ? 1.0f : -1.0f;
             out += Polyblep(phase_inc_, t);
-            out -= Polyblep(phase_inc_, fmodf(t + 0.5f, 1.0f));
+            out -= Polyblep(phase_inc_, fmodf(t + (1.0f - pw_), 1.0f));
             out *= 0.707f; // ?
             break;
         default: out = 0.0f; break;

--- a/Source/Synthesis/oscillator.cpp
+++ b/Source/Synthesis/oscillator.cpp
@@ -20,7 +20,7 @@ float Oscillator::Process()
             out = -1.0f * (((phase_ * TWO_PI_RECIP * 2.0f)) - 1.0f);
             break;
         case WAVE_RAMP: out = ((phase_ * TWO_PI_RECIP * 2.0f)) - 1.0f; break;
-        case WAVE_SQUARE: out = phase_ < PI_F ? (1.0f) : -1.0f; break;
+        case WAVE_SQUARE: out = phase_ < pw_ ? (1.0f) : -1.0f; break;
         case WAVE_POLYBLEP_TRI:
             t   = phase_ * TWO_PI_RECIP;
             out = phase_ < PI_F ? 1.0f : -1.0f;

--- a/Source/Synthesis/oscillator.h
+++ b/Source/Synthesis/oscillator.h
@@ -45,7 +45,8 @@ class Oscillator
         sr_recip_  = 1.0f / sample_rate;
         freq_      = 100.0f;
         amp_       = 0.5f;
-        pw_        = 0.5f * TWOPI_F;
+        pw_        = 0.5f;
+        pw_rad_    = pw_ * TWOPI_F;
         phase_     = 0.0f;
         phase_inc_ = CalcPhaseInc(freq_);
         waveform_  = WAVE_SIN;
@@ -76,7 +77,8 @@ class Oscillator
      */
     inline void SetPw(const float pw)
     {
-        pw_ = fclamp(pw, 0.0f, 1.0f) * TWOPI_F;
+        pw_ = fclamp(pw, 0.0f, 1.0f);
+        pw_rad_ = pw_ * TWOPI_F;
     }
 
     /** Returns true if cycle is at end of rise. Set during call to Process.
@@ -110,7 +112,7 @@ class Oscillator
   private:
     float   CalcPhaseInc(float f);
     uint8_t waveform_;
-    float   amp_, freq_, pw_;
+    float   amp_, freq_, pw_, pw_rad_;
     float   sr_, sr_recip_, phase_, phase_inc_;
     float   last_out_, last_freq_;
     bool    eor_, eoc_;

--- a/Source/Synthesis/oscillator.h
+++ b/Source/Synthesis/oscillator.h
@@ -72,12 +72,12 @@ class Oscillator
     inline void SetWaveform(const uint8_t wf)
     {
         waveform_ = wf < WAVE_LAST ? wf : WAVE_SIN;
-    }  
+    }
     /** Sets the pulse width for WAVE_SQUARE and WAVE_POLYBLEP_SQUARE (range 0 - 1)
      */
     inline void SetPw(const float pw)
     {
-        pw_ = fclamp(pw, 0.0f, 1.0f);
+        pw_     = fclamp(pw, 0.0f, 1.0f);
         pw_rad_ = pw_ * TWOPI_F;
     }
 

--- a/Source/Synthesis/oscillator.h
+++ b/Source/Synthesis/oscillator.h
@@ -45,6 +45,7 @@ class Oscillator
         sr_recip_  = 1.0f / sample_rate;
         freq_      = 100.0f;
         amp_       = 0.5f;
+        pw_        = 0.5f * TWOPI_F;
         phase_     = 0.0f;
         phase_inc_ = CalcPhaseInc(freq_);
         waveform_  = WAVE_SIN;
@@ -70,6 +71,12 @@ class Oscillator
     inline void SetWaveform(const uint8_t wf)
     {
         waveform_ = wf < WAVE_LAST ? wf : WAVE_SIN;
+    }  
+    /** Sets the pulse width for WAVE_SQUARE and WAVE_POLYBLEP_SQUARE (range 0 - 1)
+     */
+    inline void SetPw(const float pw)
+    {
+        pw_ = fclamp(pw, 0.0f, 1.0f) * TWOPI_F;
     }
 
     /** Returns true if cycle is at end of rise. Set during call to Process.
@@ -103,7 +110,7 @@ class Oscillator
   private:
     float   CalcPhaseInc(float f);
     uint8_t waveform_;
-    float   amp_, freq_;
+    float   amp_, freq_, pw_;
     float   sr_, sr_recip_, phase_, phase_inc_;
     float   last_out_, last_freq_;
     bool    eor_, eoc_;


### PR DESCRIPTION
### Summary

This change implements a configurable pulse width for the `Oscillator` class's square and polyBLEP square waveforms.

### Details

Motivation is to add a simple pulse width setting to the standard `Oscillator` class for utility as an audio waveform as well as modulation. The setting applies to both the non-bandlimited and bandlimited square waves. This ended up being rather simple.

### Audio Examples

_Dropbox links to wav files. All examples start at A=110Hz and go up 4 octaves from there._

* [Slow Sine Sweep of PW - Standard Square Wave (non-bandlimited)](https://www.dropbox.com/s/tnjsqgd0oe0gj7b/PW%20Sweep%20-%205s%20-%20Non%20Bandimited.wav?dl=0)
* [Slow Sine Sweep of PW - polyBLEP Square Wave (bandlimited)](https://www.dropbox.com/s/vhj5e2k12j9cui7/PW%20Sweep%20-%205s%20-%20Bandimited.wav?dl=0)
* [2.5hz Sine PWM - Standard Square Wave (non-bandlimited)](https://www.dropbox.com/s/tlfgnwbyhy8ar4v/PWM%202.5hz%20-%20Non%20Bandlimited.wav?dl=0)
* [2.5hz Sine PWM - polyBLEP Square Wave (bandlimited)](https://www.dropbox.com/s/vwh9ixx67jadngr/PWM%202.5hz%20-%20Bandlimited.wav?dl=0)

### Feedback/Questions

* Anything I can do better in the implementation or to follow DaisySP codebase guidelines?
* I followed the method naming `SetPw` from `BlOsc` for consistency.
* Does it make sense the way I broke out `pw_` and `pw_rad_` (pre-multiplied by two pi) to avoid extra audio rate multiplications or divisions?
* I assume it makes sense to keep `WAVE_SQUARE` and `WAVE_POLYBLEP_SQUARE` as the waveform enum names for compatibility, though these are not technically just square anymore.
* Due to inverting amplifiers in the analog signal path, the pulse width of the waveform when using it as an audio output may not actually be precisely as set, it may be inverted (e.g. a pulse width of `0.25` may result in the wave being "high" for 75% of the time instead of 25%). However when used as an LFO or other internal modulation source the pulse width does match the setting.
* Please let me know if you'd like any more examples or info!