### PR TITLE
Added option for smoother bitcrushing in Decimator

### DIFF
--- a/Source/Effects/decimator.cpp
+++ b/Source/Effects/decimator.cpp
@@ -10,6 +10,8 @@ void Decimator::Init()
     bitcrushed_        = 0.0f;
     inc_               = 0;
     threshold_         = 0;
+    smooth_crushing_   = false;
+    bit_overflow_      = 1.0f;
 }
 
 float Decimator::Process(float input)
@@ -23,10 +25,17 @@ float Decimator::Process(float input)
         inc_         = 0;
         downsampled_ = input;
     }
+
     //bitcrush
-    temp = (int32_t)(downsampled_ * 65536.0f);
+    float smoothing_temp = 1.0f;
+    if(smooth_crushing_)
+    {
+        smoothing_temp = bit_overflow_;
+    }
+    temp = (int32_t)(downsampled_ * 65536.0f * smoothing_temp);
     temp >>= bits_to_crush_; // shift off
     temp <<= bits_to_crush_; // move back with zeros
-    bitcrushed_ = (float)temp / 65536.0f;
+    bitcrushed_ = (float)temp / (65536.0f * smoothing_temp);
+
     return bitcrushed_;
 }

--- a/Source/Effects/decimator.cpp
+++ b/Source/Effects/decimator.cpp
@@ -27,15 +27,18 @@ float Decimator::Process(float input)
     }
 
     //bitcrush
-    float smoothing_temp = 1.0f;
     if(smooth_crushing_)
     {
-        smoothing_temp = bit_overflow_;
+        temp = (int32_t)(downsampled_ * 65536.0f * bit_overflow_);
+        temp >>= bits_to_crush_ + 1; // shift off
+        temp <<= bits_to_crush_ + 1; // move back with zeros
+        bitcrushed_ = (float)temp / (65536.0f * bit_overflow_);
+    } else {
+        temp = (int32_t)(downsampled_ * 65536.0f);
+        temp >>= bits_to_crush_; // shift off
+        temp <<= bits_to_crush_; // move back with zeros
+        bitcrushed_ = (float)temp / 65536.0f;
     }
-    temp = (int32_t)(downsampled_ * 65536.0f * smoothing_temp);
-    temp >>= bits_to_crush_; // shift off
-    temp <<= bits_to_crush_; // move back with zeros
-    bitcrushed_ = (float)temp / (65536.0f * smoothing_temp);
 
     return bitcrushed_;
 }

--- a/Source/Effects/decimator.cpp
+++ b/Source/Effects/decimator.cpp
@@ -33,7 +33,9 @@ float Decimator::Process(float input)
         temp >>= bits_to_crush_ + 1; // shift off
         temp <<= bits_to_crush_ + 1; // move back with zeros
         bitcrushed_ = (float)temp / (65536.0f * bit_overflow_);
-    } else {
+    }
+    else
+    {
         temp = (int32_t)(downsampled_ * 65536.0f);
         temp >>= bits_to_crush_; // shift off
         temp <<= bits_to_crush_; // move back with zeros

--- a/Source/Effects/decimator.h
+++ b/Source/Effects/decimator.h
@@ -38,8 +38,9 @@ class Decimator
     inline void SetBitcrushFactor(float bitcrush_factor)
     {
         bitcrush_factor_ = bitcrush_factor;
-        bits_to_crush_ = (uint32_t)(bitcrush_factor * kMaxBitsToCrush);
-        bit_overflow_ = 2.0f - (bitcrush_factor * 16.0f) + (float)(bits_to_crush_);
+        bits_to_crush_   = (uint32_t)(bitcrush_factor * kMaxBitsToCrush);
+        bit_overflow_
+            = 2.0f - (bitcrush_factor * 16.0f) + (float)(bits_to_crush_);
     }
 
     /** Sets the exact number of bits to crush and disables smooth crushing
@@ -47,7 +48,7 @@ class Decimator
     */
     inline void SetBitsToCrush(const uint8_t &bits)
     {
-        bits_to_crush_ = bits <= kMaxBitsToCrush ? bits : kMaxBitsToCrush;
+        bits_to_crush_   = bits <= kMaxBitsToCrush ? bits : kMaxBitsToCrush;
         smooth_crushing_ = false;
     }
 

--- a/Source/Effects/decimator.h
+++ b/Source/Effects/decimator.h
@@ -39,7 +39,7 @@ class Decimator
     {
         bitcrush_factor_ = bitcrush_factor;
         bits_to_crush_ = (uint32_t)(bitcrush_factor * kMaxBitsToCrush);
-        bit_overflow_ = 2.0f - (bitcrush_factor_ * 16.0f) - (float)(bits_to_crush_);
+        bit_overflow_ = 2.0f - (bitcrush_factor * 16.0f) + (float)(bits_to_crush_);
     }
 
     /** Sets the exact number of bits to crush and disables smooth crushing

--- a/Source/Effects/decimator.h
+++ b/Source/Effects/decimator.h
@@ -68,6 +68,9 @@ class Decimator
     /** Returns current setting of bitcrush
     */
     inline float GetBitcrushFactor() { return bitcrush_factor_; }
+    /** Returns current bitcrush setting in bits
+    */
+    inline int GetBitsToCrush() { return bits_to_crush_; }
 
   private:
     const uint8_t kMaxBitsToCrush = 16;

--- a/Source/Effects/decimator.h
+++ b/Source/Effects/decimator.h
@@ -37,19 +37,31 @@ class Decimator
     */
     inline void SetBitcrushFactor(float bitcrush_factor)
     {
-        //            bitcrush_factor_ = bitcrush_factor;
+        bitcrush_factor_ = bitcrush_factor;
         bits_to_crush_ = (uint32_t)(bitcrush_factor * kMaxBitsToCrush);
+        bit_overflow_ = 2.0f - (bitcrush_factor_ * 16.0f) - (float)(bits_to_crush_);
     }
 
-    /** Sets the exact number of bits to crush
+    /** Sets the exact number of bits to crush and disables smooth crushing
         0-16 bits
     */
     inline void SetBitsToCrush(const uint8_t &bits)
     {
         bits_to_crush_ = bits <= kMaxBitsToCrush ? bits : kMaxBitsToCrush;
+        smooth_crushing_ = false;
     }
 
+    /** Sets the smooth crushing on or off
+        true/false
+    */
+    inline void SetSmoothCrushing(bool smooth_crushing)
+    {
+        smooth_crushing_ = smooth_crushing;
+    }
 
+    /** Returns current setting of smooth crushing
+    */
+    inline bool GetSmoothCrushing() { return smooth_crushing_; }
     /** Returns current setting of downsample
     */
     inline float GetDownsampleFactor() { return downsample_factor_; }
@@ -63,6 +75,8 @@ class Decimator
     uint32_t      bits_to_crush_;
     float         downsampled_, bitcrushed_;
     uint32_t      inc_, threshold_;
+    bool          smooth_crushing_;
+    float         bit_overflow_;
 };
 } // namespace daisysp
 #endif


### PR DESCRIPTION
Added boolean option SetSmoothCrushing() to Decimator effect.
When it is enabled and bitcrushing amount is set with SetBitcrushFactor(), the bitcrushing effect doesn't jump discretely between bits, but is smoother, or has "fractional bits". When exact number of bits to crush is set with SetBitsToCrush(), smooth crushing is disabled automatically.