### PR TITLE
Don't pass Tone float params by reference

### DIFF
--- a/Source/Filters/tone.cpp
+++ b/Source/Filters/tone.cpp
@@ -13,7 +13,7 @@ void Tone::Init(float sample_rate)
     sample_rate_ = sample_rate;
 }
 
-float Tone::Process(float &in)
+float Tone::Process(float in)
 {
     float out;
 

--- a/Source/Filters/tone.h
+++ b/Source/Filters/tone.h
@@ -29,7 +29,7 @@ class Tone
 
         \param freq - frequency value in Hz. Range: Any positive value.
     */
-    inline void SetFreq(float &freq)
+    inline void SetFreq(float freq)
     {
         freq_ = freq;
         CalculateCoefficients();

--- a/Source/Filters/tone.h
+++ b/Source/Filters/tone.h
@@ -23,7 +23,7 @@ class Tone
     /** Processes one sample through the filter and returns one sample.
         in - input signal 
     */
-    float Process(float &in);
+    float Process(float in);
 
     /** Sets the cutoff frequency or half-way point of the filter.
 


### PR DESCRIPTION
### Summary

Very small change to the interface of `Tone` to accept a `float` param for the `SetCutoff` and `Process` methods by value instead of by reference.

### Details

The reason for the change is twofold:

1. Passing a cutoff freq by reference prevents usage of rvalues including constant literals, so e.g. `tone.SetFreq(5000.0f)` will not compile.
2. Passing a non-const reference would allow the reference to be modified by the method, which is obviously not the intention of the interface here.