### PR TITLE
Fix for numerical error

### DIFF
--- a/Source/Control/adenv.cpp
+++ b/Source/Control/adenv.cpp
@@ -114,7 +114,7 @@ float AdEnv::Process()
         c_inc_ = (end - beg) / (1.0f - EXPF(curve_scalar_));
     }
 
-    if(c_inc_ >= 0)
+    if(c_inc_ >= 0.0f)
     {
         c_inc_ = std::max(c_inc_, std::numeric_limits<float>::epsilon());
     }

--- a/Source/Control/adenv.cpp
+++ b/Source/Control/adenv.cpp
@@ -122,7 +122,7 @@ float AdEnv::Process()
     {
         c_inc_ = std::min(c_inc_, -std::numeric_limits<float>::epsilon());
     }
- 
+
     // update output
     val = output_;
     inc = c_inc_;

--- a/Source/Control/adenv.cpp
+++ b/Source/Control/adenv.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <math.h>
 #include "adenv.h"
 
@@ -113,7 +114,15 @@ float AdEnv::Process()
         c_inc_ = (end - beg) / (1.0f - EXPF(curve_scalar_));
     }
 
-
+    if(c_inc_ >= 0)
+    {
+        c_inc_ = std::max(c_inc_, std::numeric_limits<float>::epsilon());
+    }
+    else
+    {
+        c_inc_ = std::min(c_inc_, -std::numeric_limits<float>::epsilon());
+    }
+ 
     // update output
     val = output_;
     inc = c_inc_;


### PR DESCRIPTION
Fix for an issue where if an envelope was re-triggered when it was at the very end of the attack stage it could get locked and never complete. This was because c_inc_ could become so small (due to the delta between the current value and the target value being very small, and then divided by the sample rate) that when added to val the value of val does not change (due to floating point inaccuracies). Ensure c_inc_ is at least as big as std epsilon, so that it will always cause val to change.

[This is my first ever pull request, so apologies if this is not the correct way to contribute to DaisySP]