### PR TITLE
Fix polyblep triangle implementation

### DIFF
--- a/Source/Synthesis/oscillator.h
+++ b/Source/Synthesis/oscillator.h
@@ -46,7 +46,6 @@ class Oscillator
         freq_      = 100.0f;
         amp_       = 0.5f;
         pw_        = 0.5f;
-        pw_rad_    = pw_ * TWOPI_F;
         phase_     = 0.0f;
         phase_inc_ = CalcPhaseInc(freq_);
         waveform_  = WAVE_SIN;
@@ -75,11 +74,7 @@ class Oscillator
     }
     /** Sets the pulse width for WAVE_SQUARE and WAVE_POLYBLEP_SQUARE (range 0 - 1)
      */
-    inline void SetPw(const float pw)
-    {
-        pw_     = fclamp(pw, 0.0f, 1.0f);
-        pw_rad_ = pw_ * TWOPI_F;
-    }
+    inline void SetPw(const float pw) { pw_ = fclamp(pw, 0.0f, 1.0f); }
 
     /** Returns true if cycle is at end of rise. Set during call to Process.
     */
@@ -91,20 +86,20 @@ class Oscillator
 
     /** Returns true if cycle rising.
     */
-    inline bool IsRising() { return phase_ < PI_F; }
+    inline bool IsRising() { return phase_ < 0.5f; }
 
     /** Returns true if cycle falling.
     */
-    inline bool IsFalling() { return phase_ >= PI_F; }
+    inline bool IsFalling() { return phase_ >= 0.5f; }
 
     /** Processes the waveform to be generated, returning one sample. This should be called once per sample period.
     */
     float Process();
 
 
-    /** Adds a value 0.0-1.0 (mapped to 0.0-TWO_PI) to the current phase. Useful for PM and "FM" synthesis.
+    /** Adds a value 0.0-1.0 (equivalent to 0.0-TWO_PI) to the current phase. Useful for PM and "FM" synthesis.
     */
-    void PhaseAdd(float _phase) { phase_ += (_phase * TWOPI_F); }
+    void PhaseAdd(float _phase) { phase_ += _phase; }
     /** Resets the phase to the input argument. If no argumeNt is present, it will reset phase to 0.0;
     */
     void Reset(float _phase = 0.0f) { phase_ = _phase; }
@@ -112,7 +107,7 @@ class Oscillator
   private:
     float   CalcPhaseInc(float f);
     uint8_t waveform_;
-    float   amp_, freq_, pw_, pw_rad_;
+    float   amp_, freq_, pw_;
     float   sr_, sr_recip_, phase_, phase_inc_;
     float   last_out_, last_freq_;
     bool    eor_, eoc_;


### PR DESCRIPTION
### Summary

Fixes bug in leaky integration in `Oscillator` polyblep triangle implementation and changes `Oscillator` to use normalized phase to save a handful of multiplications in all but one case (sine).

### Details

Firstly, this changes the range of the `phase_` and `phase_inc_` variables in `Oscillator` from the previous range of 0 - 2pi to a normalized unit range of 0 - 1. The rationale for this is that the only oscillator waveform case that actually needs the 2pi radian scaled range is the sine wave - all the rest of the waveforms don't require radian units at all, and in fact have to use extra multiplications (sometimes multiple times) to normalize back to unit range anyway.

The change to unit range also resolves a bug in the polyblep triangle waveform's leaky integration code. The leaky integration line itself has not changed:

```c++
// Leaky Integrator:
// y[n] = A + x[n] + (1 - A) * y[n-1]
out       = phase_inc_ * out + (1.0f - phase_inc_) * last_out_;
```

However, previously the `phase_inc_` was theoretically in the range of 0 - pi radians (assuming a max frequency of SR/2) and thus the leaky integration was not properly normalized (in fact the second term could be negative), resulting in a heavily curved waveform – see screenshots below. The waveform shape is much more accurate now, but the output level was reduced, thus requiring a normalization scaling.

I used the example code below to verify this approach still results in significant bandlimiting vs the non-bandlimited triangle and produces waves with an equivalent amplitude. I also verified the other waveshapes are as expected.

### Artifacts

**Before the fix, polyblep triangle at 220Hz**

![Screenshot 2023-07-06 at 11 53 47](https://github.com/electro-smith/DaisySP/assets/1433497/e78eabd4-76e1-4d1a-94cf-dc820a8cd5c9)

**After the fix, polyblep triangle at 220Hz**

![Screenshot 2023-07-06 at 12 10 39](https://github.com/electro-smith/DaisySP/assets/1433497/5cd9d077-856d-4fb0-817f-9824800e8918)

**Example Code**

This code alternates between a non-bandlimited triangle and the polyblep triangle every 2 seconds, jumping up an octave on each iteration as well. This can be used to verify aliasing mitigation and compare waveshapes between the two cases.

```c++
#include "daisysp.h"
#include "daisy_seed.h"

using namespace daisysp;
using namespace daisy;

static DaisySeed  hw;
static Oscillator osc;

static void AudioCallback(AudioHandle::InterleavingInputBuffer  in,
                          AudioHandle::InterleavingOutputBuffer out,
                          size_t                                size)
{
    float sig;
    for(size_t i = 0; i < size; i += 2)
    {
        sig = osc.Process();

        // left out
        out[i] = sig;

        // right out
        out[i + 1] = sig;
    }
}

int main(void)
{
    int octave = 0;
    int wave = Oscillator::WAVE_TRI;
    // initialize seed hardware and oscillator daisysp module
    float sample_rate;
    hw.Configure();
    hw.Init();
    hw.SetAudioBlockSize(4);
    sample_rate = hw.AudioSampleRate();
    osc.Init(sample_rate);

    // Set parameters for oscillator
    osc.SetWaveform(wave);
    osc.SetFreq(220.0f);
    osc.SetAmp(0.5);
    osc.SetPw(0.25f);

    // start callback
    hw.StartAudio(AudioCallback);

    while(1) {
        System::Delay(2000);
        wave = (wave == Oscillator::WAVE_TRI) ? Oscillator::WAVE_POLYBLEP_TRI : Oscillator::WAVE_TRI;
        osc.SetWaveform(wave);
        if (wave == Oscillator::WAVE_TRI) {
            octave = (octave + 1) % 6;
            osc.SetFreq(220.0f * powf(2.f, octave));
        }
    }
}
```

