### PR TITLE
Improve Oscillator performance by avoiding fmodf

### DIFF
--- a/Source/Synthesis/oscillator.cpp
+++ b/Source/Synthesis/oscillator.cpp
@@ -21,7 +21,7 @@ float Oscillator::Process()
             t   = phase_;
             out = phase_ < 0.5f ? 1.0f : -1.0f;
             out += Polyblep(phase_inc_, t);
-            out -= Polyblep(phase_inc_, fmodf(t + 0.5f, 1.0f));
+            out -= Polyblep(phase_inc_, fastmod1f(t + 0.5f));
             // Leaky Integrator:
             // y[n] = A + x[n] + (1 - A) * y[n-1]
             out       = phase_inc_ * out + (1.0f - phase_inc_) * last_out_;
@@ -38,7 +38,7 @@ float Oscillator::Process()
             t   = phase_;
             out = phase_ < pw_ ? 1.0f : -1.0f;
             out += Polyblep(phase_inc_, t);
-            out -= Polyblep(phase_inc_, fmodf(t + (1.0f - pw_), 1.0f));
+            out -= Polyblep(phase_inc_, fastmod1f(t + (1.0f - pw_)));
             out *= 0.707f; // ?
             break;
         default: out = 0.0f; break;

--- a/Source/Utility/dsp.h
+++ b/Source/Utility/dsp.h
@@ -86,6 +86,14 @@ inline float fastroot(float f, int n)
     return f;
 }
 
+/** Significantly more efficient than fmodf(x, 1.0f) for calculating
+ *  the decimal part of a floating point value.
+ */
+inline float fastmod1f(float x)
+{
+    return x - static_cast<int>(x);
+}
+
 /** From http://openaudio.blogspot.com/2017/02/faster-log10-and-pow.html
 No approximation, pow10f(x) gives a 90% speed increase over powf(10.f, x)
 */
@@ -145,16 +153,16 @@ enum class Mapping
     LOG,
 };
 
-/** Maps a float between a specified range, using a specified curve. 
- * 
+/** Maps a float between a specified range, using a specified curve.
+ *
  *  \param in a value between 0 to 1 that will be mapped to the new range.
  *  \param min the new minimum value
  *  \param max the new maxmimum value
  *  \param curve a Mapping Value to adjust the response curve of the transformation
  *               defaults to Linear. @see Mapping
- * 
+ *
  *  When using the log curve min and max, must be greater than zero.
- * 
+ *
  *  \retval returns the transformed float within the new range.
 */
 inline float
@@ -233,11 +241,11 @@ inline float SoftClip(float x)
         return SoftLimit(x);
 }
 
-/** Quick check for Invalid float values (NaN, Inf, out of range) 
- ** \param x value passed by reference, replaced by y if invalid. 
- ** \param y value to replace x if invalidity is found. 
- ** 
- ** When DEBUG is true in the build, this will halt 
+/** Quick check for Invalid float values (NaN, Inf, out of range)
+ ** \param x value passed by reference, replaced by y if invalid.
+ ** \param y value to replace x if invalidity is found.
+ **
+ ** When DEBUG is true in the build, this will halt
  ** execution for tracing the reason for the invalidity. */
 inline void TestFloat(float &x, float y = 0.f)
 {


### PR DESCRIPTION
### Summary

Adds a `fastmod1f` method to the dsp utils header which is significantly faster than `fmodf(x, 1.0f)`, and use this in `Oscillator` for nontrivial performance gains.

### Details

This optimization really adds up when processing multiple oscillators in more complex applications and when using block-based DSP instead of sample-by-sample, but even with DaisySP defaults the savings are obvious.

I neglected to add this optimization to `BlOsc` because:

1. The measured performance gains are negligible (the cost of the rest of the DSP outweighs the optimization gain)
2. The sawtooth `fmodf` invocation has a variable second argument (not just 1.0f)


#### Performance Metrics

Measured using `CpuLoadMeter` and the basic seed oscillator example from `DaisyExamples` at Sample Rate 48kHz and  Block Size 4, with the POLYBLEP_TRI waveform.

Before:
```
Load min:  2.196%    Max:  3.372%    Average:  2.602%
```

After:
```
Load min:  1.500%    Max:  2.316%    Average:  1.607%
```