### PR TITLE
Seed setter for `WhiteNoise`

### DIFF
--- a/Source/Noise/whitenoise.h
+++ b/Source/Noise/whitenoise.h
@@ -33,6 +33,9 @@ class WhiteNoise
         return (randseed_ * coeff_) * amp_;
     }
 
+    /** sets the seed (and corrects a seed of 0 to 1) */
+    inline void SetSeed(int32_t s) { randseed_ = s == 0 ? 1 : s; }
+
   private:
     static constexpr float coeff_ = 4.6566129e-010f;
     float                  amp_;

--- a/Source/Utility/dsp.h
+++ b/Source/Utility/dsp.h
@@ -80,7 +80,7 @@ inline float fastroot(float f, int n)
     lp = (long *)(&f);
     l  = *lp;
     l -= 0x3F800000;
-    l >>= (n = 1);
+    l >>= (n - 1);
     l += 0x3F800000;
     *lp = l;
     return f;


### PR DESCRIPTION
This PR adds a setter for the seed value of the `WhiteNoise` class. Its utility should be self-explanatory.

I've also taken the liberty of correcting #190.