### PR TITLE
Remove unused parameters from CrossFade's Get functions

### DIFF
--- a/Source/Dynamics/crossfade.h
+++ b/Source/Dynamics/crossfade.h
@@ -67,7 +67,7 @@ class CrossFade
     inline float GetPos() { return pos_; }
     /** Returns current curve
     */
-    inline uint8_t GetCurve(uint8_t curve) { return curve_; }
+    inline uint8_t GetCurve() { return curve_; }
 
   private:
     float   pos_;

--- a/Source/Dynamics/crossfade.h
+++ b/Source/Dynamics/crossfade.h
@@ -64,7 +64,7 @@ class CrossFade
     inline void SetCurve(uint8_t curve) { curve_ = curve; }
     /** Returns current position
     */
-    inline float GetPos(float pos) { return pos_; }
+    inline float GetPos() { return pos_; }
     /** Returns current curve
     */
     inline uint8_t GetCurve(uint8_t curve) { return curve_; }


### PR DESCRIPTION
Currently both `GetPos()` and `GetCurve()` require input parameters that are unused. This PR removes these parameters.

This is not backwards compatible, and I'm unsure of your process around introducing breaking changes. If there is a recommend approach for overloading these functions and deprecating the existing functions, let me know and I'd be happy to make that change instead.