### PR TITLE
Add hard retrigger to adenv

### DIFF
--- a/Source/Control/adenv.cpp
+++ b/Source/Control/adenv.cpp
@@ -75,7 +75,7 @@ float AdEnv::Process()
         current_segment_ = ADENV_SEG_ATTACK;
         phase_           = 0;
         curve_x_         = 0.0f;
-        retrig_val_      = trigger_ == ReTriggerType::RESTART ? 0.0 : output_;
+        retrig_val_      = hard_trigger_ ? 0.0 : output_;
     }
 
     time_samps = (uint32_t)(segment_time_[current_segment_] * sample_rate_);

--- a/Source/Control/adenv.cpp
+++ b/Source/Control/adenv.cpp
@@ -75,7 +75,7 @@ float AdEnv::Process()
         current_segment_ = ADENV_SEG_ATTACK;
         phase_           = 0;
         curve_x_         = 0.0f;
-        retrig_val_      = output_;
+        retrig_val_      = trigger_ == ReTriggerType::RESTART ? 0.0 : output_;
     }
 
     time_samps = (uint32_t)(segment_time_[current_segment_] * sample_rate_);

--- a/Source/Control/adenv.h
+++ b/Source/Control/adenv.h
@@ -29,16 +29,6 @@ enum AdEnvSegment
     ADENV_SEG_LAST,
 };
 
-enum ReTriggerType
-{
-  /** Value for no retrigger requested **/
-  NONE = 0,
-  /** Restarts the envelope, starting at zero output level **/
-  RESTART,
-  /** Restarts the envelope, starting at the current output level **/
-  RETRIGGER,
-};
-
 /** Trigger-able envelope with adjustable min/max, and independent per-segment time control.
 
     \author shensley
@@ -70,9 +60,19 @@ class AdEnv
     */
     float Process();
 
-    /** Starts or retriggers the envelope.*/
-    inline void Trigger() { trigger_ = RETRIGGER; }
-    inline void Trigger(bool hard) { trigger_ = hard ? RESTART : RETRIGGER; }
+    /** Starts or retriggers the envelope. Default is a non-hard retrigger.*/
+    inline void Trigger()
+    {
+        trigger_      = true;
+        hard_trigger_ = false;
+    }
+    /** Starts or retriggers the envelope. If hard is true the envelope re-starts
+        from 0, if hard is false it starts from the current envelope value. */
+    inline void Trigger(bool hard)
+    {
+        trigger_      = true;
+        hard_trigger_ = hard;
+    }
     /** Sets the length of time (in seconds) for a specific segment. */
     inline void SetTime(uint8_t seg, float time) { segment_time_[seg] = time; }
     /** Sets the amount of curve applied. A positve value will create a log
@@ -103,7 +103,7 @@ class AdEnv
     float    sample_rate_, min_, max_, output_, curve_scalar_;
     float    c_inc_, curve_x_, retrig_val_;
     uint32_t phase_;
-    uint8_t  trigger_;
+    uint8_t  trigger_, hard_trigger_;
 };
 
 } // namespace daisysp

--- a/Source/Control/adenv.h
+++ b/Source/Control/adenv.h
@@ -29,6 +29,16 @@ enum AdEnvSegment
     ADENV_SEG_LAST,
 };
 
+enum ReTriggerType
+{
+  /** Value for no retrigger requested **/
+  NONE = 0,
+  /** Restarts the envelope, starting at zero output level **/
+  RESTART,
+  /** Restarts the envelope, starting at the current output level **/
+  RETRIGGER,
+};
+
 /** Trigger-able envelope with adjustable min/max, and independent per-segment time control.
 
     \author shensley
@@ -61,7 +71,8 @@ class AdEnv
     float Process();
 
     /** Starts or retriggers the envelope.*/
-    inline void Trigger() { trigger_ = 1; }
+    inline void Trigger() { trigger_ = RETRIGGER; }
+    inline void Trigger(bool hard) { trigger_ = hard ? RESTART : RETRIGGER; }
     /** Sets the length of time (in seconds) for a specific segment. */
     inline void SetTime(uint8_t seg, float time) { segment_time_[seg] = time; }
     /** Sets the amount of curve applied. A positve value will create a log


### PR DESCRIPTION
# Description
Added hard retriggering option to the adenv envelope type. I added an additional "Trigger" method that takes a "hard" boolean so as not to break any existing code.

# Testing

I'm using it in my increasingly inaccurately named polysynth pod project: https://github.com/charlieb/podsynth
Specifically I'm using it in note.h to make sure that a fast arp with a too-long AD sequence actually restarts the notes correctly. Without this functionality it's all too easy to saturate the envelope so it's always outputting 1.

# Demos / Example Code

https://github.com/charlieb/podsynth/blob/93c24e7bcd7d021277bda945dd85646bc7dfe752/note.h#L46
