### PR TITLE
Update dsp.h fastmod1f to handle negatives

### DIFF
--- a/Source/Utility/dsp.h
+++ b/Source/Utility/dsp.h
@@ -99,7 +99,7 @@ inline float fastroot(float f, int n)
  */
 inline float fastmod1f(float x)
 {
-    return x - static_cast<int>(x);
+    return x - floorf(x);
 }
 
 /** From http://openaudio.blogspot.com/2017/02/faster-log10-and-pow.html


### PR DESCRIPTION
Follow-up to my comment here https://github.com/electro-smith/DaisySP/pull/188#issuecomment-260344182 to have fastmod1f handle negative values the same way fmodf would