### PR TITLE
Fix aggressive low-end rolloff in `DcBlock`

### DIFF
--- a/Source/Utility/dcblock.cpp
+++ b/Source/Utility/dcblock.cpp
@@ -7,7 +7,7 @@ void DcBlock::Init(float sample_rate)
 {
     output_ = 0.0;
     input_  = 0.0;
-    gain_   = 0.99;
+    gain_   = expf(-2.0f * M_PI * 10.f / sample_rate);
 }
 
 float DcBlock::Process(float in)

--- a/Source/Utility/dcblock.cpp
+++ b/Source/Utility/dcblock.cpp
@@ -7,7 +7,7 @@ void DcBlock::Init(float sample_rate)
 {
     output_ = 0.0;
     input_  = 0.0;
-    gain_   = expf(-2.0f * M_PI * 10.f / sample_rate);
+    gain_   = 1.0 - 10.f / sample_rate;
 }
 
 float DcBlock::Process(float in)


### PR DESCRIPTION
# Description

The current `DcBlock` implementation in DaisySP is aggressively rolling off low frequencies. This is due to the fixed coefficient of `0.99` being used instead of one dynamically calculated based on the sample rate and approximate target corner frequency.

This change adds a dynamic pole calculation based on an approximate corner frequency of 10Hz at the given sample rate using `1 - fc/fs` which is fairly reasonable for corner frequencies below ~100Hz. The exact -3dB corner frequency of the original one-pole lowpass filter can be calculated exactly, but the curve changes when subtracting the filtered signal from the original to achieve a DC-blocking highpass as done here.

For reference, here is the filter amplitude response (at fs = 48kHz) with the original hard-coded pole coefficient of 0.99:

https://www.desmos.com/calculator/ymsix8p9aa

![desmos-graph(1)](https://github.com/user-attachments/assets/0c0be9e9-8a6f-4cc9-b7be-48dc69282c2b)

And here is the amplitude response with a dynamic pole coefficient (set initially for a ~10Hz corner freq):

https://www.desmos.com/calculator/uhcegka8st

![desmos-graph(2)](https://github.com/user-attachments/assets/2a06a68d-6450-42e4-8442-b960ff5fd3b5)

Note the significant difference - in the first example, there is already an attenuation of about -8dB at 100Hz, which only increases as the frequency gets lower. In the second example, there is only about a -0.7dB reduction at 20Hz which is much more reasonable in terms of the effect on the frequency response of the overall filter acting as a DC Blocker.

_Note: the logarithmic display of the desmos graph tool requires a non-zero minimum axis value - set it to linear to see that there is truly infinite attenuation as it approaches DC (0Hz)_

# Testing

I have been using this code in various projects for quite some time as a remedy for the originally aggressive highpass rolloff from the version with the hard-coded coefficient. The theoretical analysis above also confirms the validity of the change.

For further assurance, a `DcBlock` could be added to the simple oscillator example for the Seed, noting the reduction in amplitude of the output signal at frequencies < 100Hz in the original version compared to the update.

Finally - comparing the result of the change for a 48kHz sample rate, we get a coef of `1 - fc/fs ~= 0.9997` which is the only effective change to the code. Just a different pole coefficient.