### PR TITLE
update clang-format workflow to latest version.

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,19 +1,18 @@
 name: Style
 
-on: 
+on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.11
-      with:
-        source: 'Source'
-        extensions: 'h,cpp'
-        clangFormatVersion: 10
-
+      - uses: actions/checkout@v2
+      - uses: DoozyX/clang-format-lint-action@v0.18.2
+        with:
+          source: "Source"
+          extensions: "h,cpp"
+          clangFormatVersion: 10


### PR DESCRIPTION
This just ticks the version of the clang-format action we're using. I think the older version has some dependencies that are no longer available.