### PR TITLE
Fix glitches in soft saturation algorithm - dsp.h

### DIFF
--- a/Source/Utility/dsp.h
+++ b/Source/Utility/dsp.h
@@ -269,14 +269,14 @@ inline void TestFloat(float &x, float y = 0.f)
 
 /** Based on soft saturate from:
 [musicdsp.org](musicdsp.org/en/latest/Effects/42-soft-saturation.html)
+with 0 <= thresh <= 1
 Bram de Jong (2002-01-17)
-This still needs to be tested/fixed. Definitely does some weird stuff
 described as:
-x < a:
+x <= a:
      f(x) = x
 x > a:
      f(x) = a + (x-a)/(1+((x-a)/(1-a))^2)
-x > 1:
+x >= 1:
      f(x) = (a + 1)/2
 */
 inline float soft_saturate(float in, float thresh)
@@ -287,11 +287,11 @@ inline float soft_saturate(float in, float thresh)
     out  = 0.f;
     flip = in < 0.0f;
     val  = flip ? -in : in;
-    if(val < thresh)
+    if(val <= thresh)
     {
         out = in;
     }
-    else if(val > 1.0f)
+    else if(val >= 1.0f)
     {
         out = (thresh + 1.0f) / 2.0f;
         if(flip)
@@ -306,16 +306,8 @@ inline float soft_saturate(float in, float thresh)
             out *= -1.0f;
     }
     return out;
-    //    return val < thresh
-    //               ? val
-    //               : val > 1.0f
-    //                     ? (thresh + 1.0f) / 2.0f
-    //                     : thresh
-    //                           + (val - thresh)
-    //                                 / (1.0f
-    //                                    + (((val - thresh) / (1.0f - thresh))
-    //                                       * ((val - thresh) / (1.0f - thresh))));
 }
+
 constexpr bool is_power2(uint32_t x)
 {
     return ((x - 1) & x) == 0;


### PR DESCRIPTION
# Description

This patch fixes some identified glitches in the soft saturation algorithm (mentioned in the comments of the code itself), and removes a commented-out single return implementation. I removed this comment since it only affects the positive side of the signal, so it's not equivalent to the multi-line algorithm and fixing it would require using some mathematical functions or other tricks that would make it even harder to understand and less performant than the full implementation.
In the referred origin for the algorithm it is stated that the threshold is bound between 0 and 1. I added this info in the description of the function.
The glitches in this implementation stem from the fact that it is possible for `val` to evaluate as being equal to `thresh` while not being greater than 1.
Consider `val = thresh = 1.0f`
In this case, none of the branches of the `if else` statements will be evaluated. Since `out` is being initialized to `0.0f`, the output will be 0. If the neighboring samples are close to 1 (for example near the peak of a sinus wave), this would produce 1 sample equal to zero near samples that are close to 1.0f, therefore creating crackling sounds. There were two options to solve this issue:
1) Change `val < thresh` to `val <= thresh` (line 291) 
2) Initializing `out` to `in` instead of `0.0f` (line 288) 
I preferred the first option since in theory none of them would increase clock cycles needed to calculate the output, and the first option makes the algorithm clearer. Also the second option might produce a discontinuity if the neighbouring samples are being modified by the saturation algorithm. 

Something similar happens when val == 1.0f. This case is also not handled in the conditionals, so it will also remain zero

Note 1: I didn't commit the changes done by `util/fix_style.sh` since none of them are relevant to my changes
Note 2: `NaN` will be mapped to `0`, since according to the [IEEE 754 standard](https://en.wikipedia.org/wiki/NaN#Comparison_with_NaN), a comparison to `NaN` will always evaluate to `false`

# Testing

I created a small Qt app to visualize the effects of this code. Project is attached. Just copy all the files to the same folder and open the project file with QtCreator , or create a subdirectory called build and from there run (there needs to be a Qt 5.15 version installed in the system):
```
qmake ../*.pro
make
```
I also added a screenshot of the issue taken with the test app

# Demos / Example Code
[testDaisySoftSaturationFix.zip](https://github.com/user-attachments/files/22952792/testDaisySoftSaturationFix.zip)

Original plot of the problem x = a
<img width="894" height="674" alt="Screenshot from 2025-10-16 16-44-45" src="https://github.com/user-attachments/assets/9980119c-f3a1-47a0-9cc2-caa3a5dd5b84" />
Fix described in 1)
<img width="894" height="674" alt="Screenshot from 2025-10-16 16-45-00" src="https://github.com/user-attachments/assets/61b326c0-4d59-44fc-aa64-8137a5d57a39" />
Fix described in 2)
<img width="894" height="674" alt="Screenshot from 2025-10-16 16-45-16" src="https://github.com/user-attachments/assets/458321be-997c-4a21-8883-daca7918ccd8" />
Illustrating the issue with the commented -out version
<img width="894" height="674" alt="Screenshot from 2025-10-16 16-45-39" src="https://github.com/user-attachments/assets/d6d25657-cea5-4045-82c9-536c77925455" />
Illustrating the issue with x = 1.0f
<img width="894" height="674" alt="Screenshot from 2025-10-16 16-53-18" src="https://github.com/user-attachments/assets/8981331f-911a-424c-be94-e1047642ee31" />
<img width="894" height="674" alt="Screenshot from 2025-10-16 16-47-04" src="https://github.com/user-attachments/assets/d01d06bf-d1c2-4a7e-9751-66e7fde5bfaf" />

